### PR TITLE
fix: change brand email,name and url with default

### DIFF
--- a/app/controllers/super_admin/installation_configs_controller.rb
+++ b/app/controllers/super_admin/installation_configs_controller.rb
@@ -22,7 +22,7 @@ class SuperAdmin::InstallationConfigsController < SuperAdmin::ApplicationControl
   # this will be used to set the records shown on the `index` action.
   #
   def scoped_resource
-    resource_class.editable
+    resource_class
   end
 
   # Override `resource_params` if you want to transform the submitted

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,7 @@
 class ApplicationMailer < ActionMailer::Base
   include ActionView::Helpers::SanitizeHelper
 
-  default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
+  default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Julian at Cruise Control <support@getcruisecontrol.com>')
   before_action { ensure_current_account(params.try(:[], :account)) }
   around_action :switch_locale
   layout 'mailer/base'

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -1,6 +1,6 @@
 class ConversationReplyMailer < ApplicationMailer
   include ConversationReplyMailerHelper
-  default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
+  default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Julian at Cruise Control <support@getcruisecontrol.com>')
   layout :choose_layout
 
   def reply_with_summary(conversation, last_queued_id)

--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -152,7 +152,7 @@ class MailPresenter < SimpleDelegator
 
   def notification_email_from_chatwoot?
     # notification emails are send via mailer sender email address. so it should match
-    original_sender == Mail::Address.new(ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')).address
+    original_sender == Mail::Address.new(ENV.fetch('MAILER_SENDER_EMAIL', 'Julian at Cruise Control <support@getcruisecontrol.com>')).address
   end
 
   private

--- a/app/views/super_admin/application/_navigation.html.erb
+++ b/app/views/super_admin/application/_navigation.html.erb
@@ -16,6 +16,7 @@ as defined by the routes in the `admin/` namespace
     users: 'icon-user-follow-line',
     platform_apps: 'icon-apps-2-line',
     agent_bots: 'icon-robot-line',
+    installation_configs: 'icon-settings-2-line'
   }
 %>
 
@@ -32,7 +33,7 @@ as defined by the routes in the `admin/` namespace
     <ul class="my-4">
       <%= render partial: "nav_item", locals: { icon: 'icon-grid-line', url: super_admin_root_url, label: 'Dashboard' } %>
       <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
-        <% next if ["account_users", "access_tokens", "installation_configs", "dashboard", "devise/sessions", "app_configs", "instance_statuses", "settings"].include?  resource.resource %>
+        <% next if ["account_users", "access_tokens", "dashboard", "devise/sessions", "app_configs", "instance_statuses", "settings"].include?  resource.resource %>
         <%= render partial: "nav_item", locals: {
             icon: sidebar_icons[resource.resource.to_sym],
             url: resource_index_route(resource),

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
+  config.mailer_sender = ENV.fetch('MAILER_SENDER_EMAIL', 'Julian at Cruise Control <support@getcruisecontrol.com>')
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/spec/fixtures/files/notification.eml
+++ b/spec/fixtures/files/notification.eml
@@ -40,7 +40,7 @@ Authentication-Results: mx.google.com;
 DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple; s=jywwku4pypva75vx2ayl2qfvg46arq6j; d=chatwoot.com; t=1580563433; h=Date:From:To:Message-ID:Subject:Mime-Version:Content-Type:Content-Transfer-Encoding; bh=sidGViYBMVWvZmddU9y4tJbPdSakZIQ0SRFD7VFPP88=; b=S/vIfBFOWSSX45lxfB5jZsT0/Jb9NZefnlLdmF8yicPNiV2/H8HtDAqyO3JqHLfM fPefZPKhYhzBqfxoEEFAY/vr7ov8XT+D4Y+VCv1zl0fiyytTntJ/uQztF5Eg61j+Tqj JPgRqJRdfW0g+E06CH1vhVPVzD8jIpUGnZ6gVEl4=
 DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1580563433; h=Date:From:To:Message-ID:Subject:Mime-Version:Content-Type:Content-Transfer-Encoding:Feedback-ID; bh=sidGViYBMVWvZmddU9y4tJbPdSakZIQ0SRFD7VFPP88=; b=b0rWlX4Vo8FpaGzSe57iuHhxj/d57qliYmPmv0mBn/0ZEmGjkBlNYbE0An7T3Jmk Pu2TIOr71f9H/DLnMw9n8ro4Orl/ISn26uYfttP4u6iCOCEDV6/BC3xvlpSvg7R9Sin yHhY0LWM/F5zTFPO7EfOt+ibS33LXOKFseQVzpfI=
 Date: Sat, 1 Feb 2020 13:23:53 +0000
-From: accounts@chatwoot.com
+From: support@getcruisecontrol.com
 To: sojan@chatwoot.com
 Message-ID: <0101017000ec0605-2b97eb32-482d-4357-8715-29b1d4a7c38b-000000@us-west-2.amazonses.com>
 Subject: Sojan, A new conversation [ID - 873] has been assigned to you.

--- a/spec/mailers/confirmation_instructions_spec.rb
+++ b/spec/mailers/confirmation_instructions_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Devise::Mailer' do
     end
 
     it 'has the correct header data' do
-      expect(mail.reply_to).to contain_exactly('accounts@chatwoot.com')
+      expect(mail.reply_to).to contain_exactly('support@getcruisecontrol.com')
       expect(mail.to).to contain_exactly(confirmable_user.email)
       expect(mail.subject).to eq('Confirmation Instructions')
     end


### PR DESCRIPTION
## Description
This pull request addresses copy changes of brand default sender email with ability to change brand name, url and other settings from Super Admin dashboard from  here: {baseURL/super_admin/installation_configs}

**Release Notes:**
-   Changed the sender's email to: Julian at Cruise Control support@getcruisecontrol.com for all outgoing emails.
-   Brand URL can change from Super Admin dashboard from  here: {baseURL/super_admin/installation_configs}
-   Here are list of emails sending by default from system, as no transactional related email found in list. Here are the subject of list of default emails. Might be it helps:
     **Your Slack integration has expired'
     Your Dialogflow integration was disconnected
     Your Facebook page connection has expired
     Your Whatsapp connection has expired
     Your email inbox has been disconnected. Please update the      credentials for SMTP/IMAP
     Contact Import Completed
     Contact Import Failed
     John  -A new conversation [ID - {ConversationID} has been created in {ConversationName}.
     Email sent from #{email_from} to #{to_emails} with subject reply_with_summary/reply_without_summary/email_replyconversation_transcript.**
-   No Contact information of brand found in footer by default. We could ours if required.
-   The default thumbnail logo has been shared over notion to replace it with our brand.
