### PR TITLE
fix: CRUISE-101 - change brand email,name and url with default

### DIFF
--- a/app/controllers/super_admin/installation_configs_controller.rb
+++ b/app/controllers/super_admin/installation_configs_controller.rb
@@ -22,7 +22,7 @@ class SuperAdmin::InstallationConfigsController < SuperAdmin::ApplicationControl
   # this will be used to set the records shown on the `index` action.
   #
   def scoped_resource
-    resource_class.editable
+    resource_class
   end
 
   # Override `resource_params` if you want to transform the submitted

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,7 @@
 class ApplicationMailer < ActionMailer::Base
   include ActionView::Helpers::SanitizeHelper
 
-  default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
+  default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Julian at Cruise Control <support@getcruisecontrol.com>')
   before_action { ensure_current_account(params.try(:[], :account)) }
   around_action :switch_locale
   layout 'mailer/base'

--- a/app/mailers/conversation_reply_mailer.rb
+++ b/app/mailers/conversation_reply_mailer.rb
@@ -1,6 +1,6 @@
 class ConversationReplyMailer < ApplicationMailer
   include ConversationReplyMailerHelper
-  default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
+  default from: ENV.fetch('MAILER_SENDER_EMAIL', 'Julian at Cruise Control <support@getcruisecontrol.com>')
   layout :choose_layout
 
   def reply_with_summary(conversation, last_queued_id)

--- a/app/presenters/mail_presenter.rb
+++ b/app/presenters/mail_presenter.rb
@@ -152,7 +152,7 @@ class MailPresenter < SimpleDelegator
 
   def notification_email_from_chatwoot?
     # notification emails are send via mailer sender email address. so it should match
-    original_sender == Mail::Address.new(ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')).address
+    original_sender == Mail::Address.new(ENV.fetch('MAILER_SENDER_EMAIL', 'Julian at Cruise Control <support@getcruisecontrol.com>')).address
   end
 
   private

--- a/app/views/installation/onboarding/index.html.erb
+++ b/app/views/installation/onboarding/index.html.erb
@@ -12,7 +12,7 @@
           <img src="/brand-assets/logo.svg" alt="Chatwoot" class="mx-auto h-8 w-auto block dark:hidden">
           <img src="/brand-assets/logo_dark.svg" alt="Chatwoot" class="mx-auto h-8 w-auto hidden dark:block">
           <h2 class="mt-6 text-center text-3xl font-medium text-slate-900 dark:text-woot-50">
-            Howdy, Welcome to Chatwoot 👋
+            Howdy, Welcome to Cruise Control 👋
           </h2>
         </section>
         <section class="bg-white shadow sm:mx-auto mt-11 sm:w-full sm:max-w-lg dark:bg-slate-800 p-11 sm:shadow-lg sm:rounded-lg mb-8 mt-15">

--- a/app/views/super_admin/application/_navigation.html.erb
+++ b/app/views/super_admin/application/_navigation.html.erb
@@ -16,6 +16,7 @@ as defined by the routes in the `admin/` namespace
     users: 'icon-user-follow-line',
     platform_apps: 'icon-apps-2-line',
     agent_bots: 'icon-robot-line',
+    installation_configs: 'icon-settings-2-line'
   }
 %>
 
@@ -32,7 +33,7 @@ as defined by the routes in the `admin/` namespace
     <ul class="my-4">
       <%= render partial: "nav_item", locals: { icon: 'icon-grid-line', url: super_admin_root_url, label: 'Dashboard' } %>
       <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
-        <% next if ["account_users", "access_tokens", "installation_configs", "dashboard", "devise/sessions", "app_configs", "instance_statuses", "settings"].include?  resource.resource %>
+        <% next if ["account_users", "access_tokens", "dashboard", "devise/sessions", "app_configs", "instance_statuses", "settings"].include?  resource.resource %>
         <%= render partial: "nav_item", locals: {
             icon: sidebar_icons[resource.resource.to_sym],
             url: resource_index_route(resource),

--- a/app/views/super_admin/application/_navigation.html.erb
+++ b/app/views/super_admin/application/_navigation.html.erb
@@ -23,9 +23,9 @@ as defined by the routes in the `admin/` namespace
 <div class="border-slate-100 border-r w-56 flex-shrink-0 justify-between h-full flex flex-col" role="navigation">
   <div>
     <div class="flex mx-4 mb-4 border-slate-100 border-b py-6">
-      <%= link_to image_tag('/brand-assets/logo_thumbnail.svg', alt: 'Chatwoot Admin Dashboard', class: 'h-10'), super_admin_root_url %>
+      <%= link_to image_tag('/brand-assets/logo_thumbnail.svg', alt: 'Cruise Control Admin Dashboard', class: 'h-10'), super_admin_root_url %>
       <div class="flex flex-col ml-3">
-        <div class="text-sm">Chatwoot <%= Chatwoot.config[:version] %></div>
+        <div class="text-sm">Cruise Control</div>
         <div class="text-xs text-slate-700 mt-0.5">Super Admin Console</div>
       </div>
     </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV.fetch('MAILER_SENDER_EMAIL', 'Chatwoot <accounts@chatwoot.com>')
+  config.mailer_sender = ENV.fetch('MAILER_SENDER_EMAIL', 'Julian at Cruise Control <support@getcruisecontrol.com>')
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -14,7 +14,7 @@
 
 # ------- Branding Related Config ------- #
 - name: INSTALLATION_NAME
-  value: 'Chatwoot'
+  value: 'Cruise Control'
   display_title: 'Installation Name'
   description: 'The installation wide name that would be used in the dashboard, title etc.'
 - name: LOGO_THUMBNAIL
@@ -30,15 +30,15 @@
   display_title: 'Logo Dark Mode'
   description: 'The logo that would be used on the dashboard, login page etc. for dark mode'
 - name: BRAND_URL
-  value: 'https://www.chatwoot.com'
+  value: 'https://getcruisecontrol.com'
   display_title: 'Brand URL'
   description: 'The URL that would be used in emails under the section “Powered By”'
 - name: WIDGET_BRAND_URL
-  value: 'https://www.chatwoot.com'
+  value: 'https://getcruisecontrol.com'
   display_title: 'Widget Brand URL'
   description: 'The URL that would be used in the widget under the section “Powered By”'
 - name: BRAND_NAME
-  value: 'Chatwoot'
+  value: 'Cruise Control'
   display_title: 'Brand Name'
   description: 'The name that would be used in emails and the widget'
 - name: TERMS_URL

--- a/enterprise/config/premium_installation_config.yml
+++ b/enterprise/config/premium_installation_config.yml
@@ -1,6 +1,6 @@
 # ------- Branding Related Config ------- #
 - name: INSTALLATION_NAME
-  value: 'Chatwoot'
+  value: 'Cruise Control'
 - name: LOGO_THUMBNAIL
   value: '/brand-assets/logo_thumbnail.svg'
 - name: LOGO
@@ -8,11 +8,11 @@
 - name: LOGO_DARK
   value: '/brand-assets/logo_dark.svg'
 - name: BRAND_URL
-  value: 'https://www.chatwoot.com'
+  value: 'https://getcruisecontrol.com'
 - name: WIDGET_BRAND_URL
-  value: 'https://www.chatwoot.com'
+  value: 'https://getcruisecontrol.com'
 - name: BRAND_NAME
-  value: 'Chatwoot'
+  value: 'Cruise Control'
 - name: TERMS_URL
   value: 'https://www.chatwoot.com/terms-of-service'
 - name: PRIVACY_URL

--- a/spec/fixtures/files/notification.eml
+++ b/spec/fixtures/files/notification.eml
@@ -40,7 +40,7 @@ Authentication-Results: mx.google.com;
 DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple; s=jywwku4pypva75vx2ayl2qfvg46arq6j; d=chatwoot.com; t=1580563433; h=Date:From:To:Message-ID:Subject:Mime-Version:Content-Type:Content-Transfer-Encoding; bh=sidGViYBMVWvZmddU9y4tJbPdSakZIQ0SRFD7VFPP88=; b=S/vIfBFOWSSX45lxfB5jZsT0/Jb9NZefnlLdmF8yicPNiV2/H8HtDAqyO3JqHLfM fPefZPKhYhzBqfxoEEFAY/vr7ov8XT+D4Y+VCv1zl0fiyytTntJ/uQztF5Eg61j+Tqj JPgRqJRdfW0g+E06CH1vhVPVzD8jIpUGnZ6gVEl4=
 DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1580563433; h=Date:From:To:Message-ID:Subject:Mime-Version:Content-Type:Content-Transfer-Encoding:Feedback-ID; bh=sidGViYBMVWvZmddU9y4tJbPdSakZIQ0SRFD7VFPP88=; b=b0rWlX4Vo8FpaGzSe57iuHhxj/d57qliYmPmv0mBn/0ZEmGjkBlNYbE0An7T3Jmk Pu2TIOr71f9H/DLnMw9n8ro4Orl/ISn26uYfttP4u6iCOCEDV6/BC3xvlpSvg7R9Sin yHhY0LWM/F5zTFPO7EfOt+ibS33LXOKFseQVzpfI=
 Date: Sat, 1 Feb 2020 13:23:53 +0000
-From: accounts@chatwoot.com
+From: support@getcruisecontrol.com
 To: sojan@chatwoot.com
 Message-ID: <0101017000ec0605-2b97eb32-482d-4357-8715-29b1d4a7c38b-000000@us-west-2.amazonses.com>
 Subject: Sojan, A new conversation [ID - 873] has been assigned to you.

--- a/spec/mailers/confirmation_instructions_spec.rb
+++ b/spec/mailers/confirmation_instructions_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Devise::Mailer' do
     end
 
     it 'has the correct header data' do
-      expect(mail.reply_to).to contain_exactly('accounts@chatwoot.com')
+      expect(mail.reply_to).to contain_exactly('support@getcruisecontrol.com')
       expect(mail.to).to contain_exactly(confirmable_user.email)
       expect(mail.subject).to eq('Confirmation Instructions')
     end


### PR DESCRIPTION
## Description
This pull request addresses copy changes of brand default sender email with ability to change brand name, url and other settings from Super Admin dashboard from  here: {baseURL/super_admin/installation_configs}

**Release Notes:**
-   Changed the sender's email to: Julian at Cruise Control support@getcruisecontrol.com for all outgoing emails.
-   Brand URL can change from Super Admin dashboard from  here: {baseURL/super_admin/installation_configs}
-   Here are list of emails sending by default from system, as no transactional related email found in list. Here are the subject of list of default emails. Might be it helps:
     **Your Slack integration has expired'
     Your Dialogflow integration was disconnected
     Your Facebook page connection has expired
     Your Whatsapp connection has expired
     Your email inbox has been disconnected. Please update the      credentials for SMTP/IMAP
     Contact Import Completed
     Contact Import Failed
     John  -A new conversation [ID - {ConversationID} has been created in {ConversationName}.
     Email sent from #{email_from} to #{to_emails} with subject reply_with_summary/reply_without_summary/email_replyconversation_transcript.**
-   No Contact information of brand found in footer by default. We could ours if required.
-   The default thumbnail logo has been shared over notion to replace it with our brand.
