### PR TITLE
fix: CRUISE-124 - verified the acceptance of work/normal emails for on-boarding!

### DIFF
--- a/app/javascript/dashboard/i18n/locale/am/login.json
+++ b/app/javascript/dashboard/i18n/locale/am/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/am/signup.json
+++ b/app/javascript/dashboard/i18n/locale/am/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },

--- a/app/javascript/dashboard/i18n/locale/ar/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ar/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "تسجيل",
     "TESTIMONIAL_HEADER": "إن كل ما يلزم هو خطوة واحدة للمضي قدما",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "من خلال التسجيل، فإنك توافق على <a href=\"https://www.chatwoot.com/terms\">شروط الخدمة</a> و <a href=\"https://www.chatwoot.com/privacy-policy\">سياسة الخصوصية</a>",
+    "TERMS_ACCEPT": "من خلال التسجيل، فإنك توافق على <a href=\"https://getcruisecontrol.com/terms\">شروط الخدمة</a> و <a href=\"https://getcruisecontrol.com/privacy-policy\">سياسة الخصوصية</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },

--- a/app/javascript/dashboard/i18n/locale/az/login.json
+++ b/app/javascript/dashboard/i18n/locale/az/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/az/signup.json
+++ b/app/javascript/dashboard/i18n/locale/az/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },

--- a/app/javascript/dashboard/i18n/locale/bg/login.json
+++ b/app/javascript/dashboard/i18n/locale/bg/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/bg/signup.json
+++ b/app/javascript/dashboard/i18n/locale/bg/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },

--- a/app/javascript/dashboard/i18n/locale/ca/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ca/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registre",
     "TESTIMONIAL_HEADER": "Només cal un pas per avançar",
     "TESTIMONIAL_CONTENT": "Esteu a un pas de captar els vostres clients, retenir-los i trobar-ne de nous.",
-    "TERMS_ACCEPT": "En crear un compte, acceptes els nostres <a href=\"https://www.chatwoot.com/terms\">T&C</a> i <a href=\"https://www.chatwoot.com/privacy-policy\">Política de privadesa</a>",
+    "TERMS_ACCEPT": "En crear un compte, acceptes els nostres <a href=\"https://getcruisecontrol.com/terms\">T&C</a> i <a href=\"https://getcruisecontrol.com/privacy-policy\">Política de privadesa</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Registra't amb Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Email de treball",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}wayne{'.'}enterprises",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "Contrasenya",

--- a/app/javascript/dashboard/i18n/locale/cs/signup.json
+++ b/app/javascript/dashboard/i18n/locale/cs/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registrovat se",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },

--- a/app/javascript/dashboard/i18n/locale/da/signup.json
+++ b/app/javascript/dashboard/i18n/locale/da/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registrer",
     "TESTIMONIAL_HEADER": "Alt, hvad der skal til, er blot et skridt for at komme videre",
     "TESTIMONIAL_CONTENT": "Du er et skridt fra at engagere dine kunder, fastholde dem og finde nye kunder.",
-    "TERMS_ACCEPT": "Ved at oprette en konto, accepterer du vores <a href=\"https://www.chatwoot.com/terms\">T & C</a> og <a href=\"https://www.chatwoot.com/privacy-policy\">Privatlivspolitik</a>",
+    "TERMS_ACCEPT": "Ved at oprette en konto, accepterer du vores <a href=\"https://getcruisecontrol.com/terms\">T & C</a> og <a href=\"https://getcruisecontrol.com/privacy-policy\">Privatlivspolitik</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Tilmeld dig med Google"
     },

--- a/app/javascript/dashboard/i18n/locale/de/signup.json
+++ b/app/javascript/dashboard/i18n/locale/de/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registrieren",
     "TESTIMONIAL_HEADER": "Alles, was er braucht, ist ein Schritt, um vorwärtszugehen",
     "TESTIMONIAL_CONTENT": "Sie sind nur noch einen Schritt davon entfernt, Ihre Kunden zu gewinnen, zu binden und neue zu finden.",
-    "TERMS_ACCEPT": "Durch die Erstellung eines Kontos stimmen Sie unseren <a href=\"https://www.chatwoot.com/terms-of-service\">Allgemeinn Geschäftsbedingungen</a> und unserer <a href=\"https://www.chatwoot.com/privacy-policy\">Datenschutzrichtlinie</a> zu",
+    "TERMS_ACCEPT": "Durch die Erstellung eines Kontos stimmen Sie unseren <a href=\"https://getcruisecontrol.com/terms-of-service\">Allgemeinn Geschäftsbedingungen</a> und unserer <a href=\"https://getcruisecontrol.com/privacy-policy\">Datenschutzrichtlinie</a> zu",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Mit Google anmelden"
     },
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Geschäftliche E-Mail-Adresse",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
       "ERROR": "Bitte geben Sie eine gültige Arbeits-E-Mail-Adresse ein"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/el/signup.json
+++ b/app/javascript/dashboard/i18n/locale/el/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Καταχώρηση",
     "TESTIMONIAL_HEADER": "Το μόνο που χρειάζεται είναι ένα βήμα για να προχωρήσουμε",
     "TESTIMONIAL_CONTENT": "Είστε ένα βήμα μακριά από την εμπλοκή των πελατών σας, και την εύρεση νέων.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },

--- a/app/javascript/dashboard/i18n/locale/en/login.json
+++ b/app/javascript/dashboard/i18n/locale/en/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/en/signup.json
+++ b/app/javascript/dashboard/i18n/locale/en/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address."
     },
     "PASSWORD": {
       "LABEL": "Password",

--- a/app/javascript/dashboard/i18n/locale/es/signup.json
+++ b/app/javascript/dashboard/i18n/locale/es/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registrarse",
     "TESTIMONIAL_HEADER": "Todo lo que se necesita es un paso adelante",
     "TESTIMONIAL_CONTENT": "Usted está a un paso de involucrar a sus clientes, conservarlos y encontrar nuevos.",
-    "TERMS_ACCEPT": "Al crear una cuenta, aceptas nuestros <a href=\"https://www.chatwoot.com/terms\">Términos y condiciones</a> y nuestra <a href=\"https://www.chatwoot.com/privacy-policy\">Política de privacidad</a>",
+    "TERMS_ACCEPT": "Al crear una cuenta, aceptas nuestros <a href=\"https://getcruisecontrol.com/terms\">Términos y condiciones</a> y nuestra <a href=\"https://getcruisecontrol.com/privacy-policy\">Política de privacidad</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Registrarse con Google"
     },
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "E-mail",
-      "PLACEHOLDER": "Introduzca su dirección de correo electrónico de trabajo. Por ejemplo, bruce{'@'}wayne{'.'}empresas",
+      "PLACEHOLDER": "Introduzca su dirección de correo electrónico de trabajo. Por ejemplo, bruce{'@'}example{'.'}com",
       "ERROR": "Por favor, introduzca una dirección de correo válida"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/fa/signup.json
+++ b/app/javascript/dashboard/i18n/locale/fa/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "ثبت نام",
     "TESTIMONIAL_HEADER": "تنها چیزی که لازم است یک قدم برای حرکت به جلو است",
     "TESTIMONIAL_CONTENT": "شما یک قدم تا جذب مشتریان خود، حفظ آنها و یافتن مشتریان جدید فاصله دارید.",
-    "TERMS_ACCEPT": "با ایجاد یک حساب کاربری، با <a href=\"https://www.chatwoot.com/terms\">T & C</a> و <a href=\"https://www.chatwoot.com/ ما موافقت می کنید privacy-policy\">خط مشی رازداری</a>",
+    "TERMS_ACCEPT": "با ایجاد یک حساب کاربری، با <a href=\"https://getcruisecontrol.com/terms\">T & C</a> و <a href=\"https://getcruisecontrol.com/ ما موافقت می کنید privacy-policy\">خط مشی رازداری</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "با گوگل ثبت نام کنید"
     },

--- a/app/javascript/dashboard/i18n/locale/fi/signup.json
+++ b/app/javascript/dashboard/i18n/locale/fi/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Rekisteröidy",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Työsähköposti",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
       "ERROR": "Syötä voimassa oleva työsähköpostiosoite."
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/fr/signup.json
+++ b/app/javascript/dashboard/i18n/locale/fr/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Inscription",
     "TESTIMONIAL_HEADER": "Il suffit d'une étape pour avancer",
     "TESTIMONIAL_CONTENT": "Vous n'êtes plus qu'à un pas d'engager vos clients, de les fidéliser et d'en trouver de nouveaux.",
-    "TERMS_ACCEPT": "En créant un compte, vous acceptez nos <a href=\"https://www.chatwoot.com/terms\">CGU</a> et notre <a href=\"https://www.chatwoot.com/privacy-policy\">Politique de confidentialité</a>",
+    "TERMS_ACCEPT": "En créant un compte, vous acceptez nos <a href=\"https://getcruisecontrol.com/terms\">CGU</a> et notre <a href=\"https://getcruisecontrol.com/privacy-policy\">Politique de confidentialité</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Inscrivez-vous avec Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "E-mail professionnel",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Veuillez entrer une adresse e-mail professionnelle valide"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Veuillez entrer une adresse e-mail valide"
     },
     "PASSWORD": {
       "LABEL": "Mot de passe",

--- a/app/javascript/dashboard/i18n/locale/he/signup.json
+++ b/app/javascript/dashboard/i18n/locale/he/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "הירשם",
     "TESTIMONIAL_HEADER": "כל מה שצריך זה צעד אחד כדי להתקדם",
     "TESTIMONIAL_CONTENT": "אתה במרחק צעד אחד מלהפעיל את הלקוחות שלך, לשמר אותם ולמצוא חדשים.",
-    "TERMS_ACCEPT": "על ידי יצירת חשבון, אתה מסכים ל<a href=\"https://www.chatwoot.com/terms\">תנאים וההגבלות</a> ול-<a href=\"https://www.chatwoot.com/ שלנו privacy-policy\">מדיניות הפרטיות</a>",
+    "TERMS_ACCEPT": "על ידי יצירת חשבון, אתה מסכים ל<a href=\"https://getcruisecontrol.com/terms\">תנאים וההגבלות</a> ול-<a href=\"https://getcruisecontrol.com/ שלנו privacy-policy\">מדיניות הפרטיות</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "הירשם לגוגל"
     },
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "מייל עבודה",
-      "PLACEHOLDER": "הכנס את כתובת הדוא\"ל של מקום העבודה שלך. לדוגמא: bruce{'@'}wayne{'.'}enterprises",
+      "PLACEHOLDER": "הכנס את כתובת הדוא\"ל של מקום העבודה שלך. לדוגמא: bruce{'@'}example{'.'}com",
       "ERROR": "אנא הזן כתובת דוא\"ל חוקית לעבודה"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/hi/login.json
+++ b/app/javascript/dashboard/i18n/locale/hi/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/hi/signup.json
+++ b/app/javascript/dashboard/i18n/locale/hi/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "Password",

--- a/app/javascript/dashboard/i18n/locale/hr/login.json
+++ b/app/javascript/dashboard/i18n/locale/hr/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/hr/signup.json
+++ b/app/javascript/dashboard/i18n/locale/hr/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "Password",

--- a/app/javascript/dashboard/i18n/locale/hu/signup.json
+++ b/app/javascript/dashboard/i18n/locale/hu/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Regisztrálás",
     "TESTIMONIAL_HEADER": "Már csak egy lépés van hátra",
     "TESTIMONIAL_CONTENT": "Már csak egy lépésre vagy!",
-    "TERMS_ACCEPT": "A fiók létrehozásával elfogadod az <a href=\"https://www.chatwoot.com/terms\">ÁSZF</a> és az <a href=\"https://www.chatwoot.com/privacy-policy\">Adatkezelési nyilatkozat</a> tartalmát",
+    "TERMS_ACCEPT": "A fiók létrehozásával elfogadod az <a href=\"https://getcruisecontrol.com/terms\">ÁSZF</a> és az <a href=\"https://getcruisecontrol.com/privacy-policy\">Adatkezelési nyilatkozat</a> tartalmát",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Regisztráció Google-el"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Munkahelyi e-mail",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "Jelszó",

--- a/app/javascript/dashboard/i18n/locale/hy/login.json
+++ b/app/javascript/dashboard/i18n/locale/hy/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/hy/signup.json
+++ b/app/javascript/dashboard/i18n/locale/hy/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "Password",

--- a/app/javascript/dashboard/i18n/locale/id/signup.json
+++ b/app/javascript/dashboard/i18n/locale/id/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Daftar",
     "TESTIMONIAL_HEADER": "Hanya butuh satu langkah untuk maju",
     "TESTIMONIAL_CONTENT": "Anda hanya tinggal selangkah lagi untuk berinteraksi dengan pelanggan Anda, mempertahankan mereka, dan menemukan yang baru.",
-    "TERMS_ACCEPT": "Dengan membuat akun, Anda menyetujui <a href=\"https://www.chatwoot.com/terms\">Syarat & Ketentuan</a> dan <a href=\"https://www.chatwoot.com/privacy-policy\">Kebijakan Privasi</a> kami.",
+    "TERMS_ACCEPT": "Dengan membuat akun, Anda menyetujui <a href=\"https://getcruisecontrol.com/terms\">Syarat & Ketentuan</a> dan <a href=\"https://getcruisecontrol.com/privacy-policy\">Kebijakan Privasi</a> kami.",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Daftar dengan Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Email kantor",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Harap masukkan alamat email kantor yang valid"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Harap masukkan alamat email yang valid"
     },
     "PASSWORD": {
       "LABEL": "Kata Sandi",

--- a/app/javascript/dashboard/i18n/locale/is/login.json
+++ b/app/javascript/dashboard/i18n/locale/is/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Tölvupóstfang",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/is/signup.json
+++ b/app/javascript/dashboard/i18n/locale/is/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Nýskráning",
     "TESTIMONIAL_HEADER": "Það þarf aðeins eitt skref framávið",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Vinnu netfang",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
       "ERROR": "Vinsamlegast sláðu inn gilt vinnu netfang"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/it/signup.json
+++ b/app/javascript/dashboard/i18n/locale/it/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registrati",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Email di lavoro",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
       "ERROR": "Si prega di inserire un indirizzo email di lavoro valido."
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/ja/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ja/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "登録",
     "TESTIMONIAL_HEADER": "前進するために必要なのはたった一歩",
     "TESTIMONIAL_CONTENT": "顧客と関わり、維持し、新たな顧客を見つけるまであと一歩です。",
-    "TERMS_ACCEPT": "アカウントを作成することで、<a href=\"https://www.chatwoot.com/terms\">利用規約</a>および<a href=\"https://www.chatwoot.com/privacy-policy\">プライバシーポリシー</a>に同意したものとみなされます。",
+    "TERMS_ACCEPT": "アカウントを作成することで、<a href=\"https://getcruisecontrol.com/terms\">利用規約</a>および<a href=\"https://getcruisecontrol.com/privacy-policy\">プライバシーポリシー</a>に同意したものとみなされます。",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Googleで登録"
     },
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "勤務先のメールアドレス",
-      "PLACEHOLDER": "勤務先のメールアドレスを入力してください。例: bruce{'@'}wayne{'.'}enterprises",
+      "PLACEHOLDER": "勤務先のメールアドレスを入力してください。例: bruce{'@'}example{'.'}com",
       "ERROR": "有効な勤務先のメールアドレスを入力してください"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/ka/login.json
+++ b/app/javascript/dashboard/i18n/locale/ka/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/ka/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ka/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "Password",

--- a/app/javascript/dashboard/i18n/locale/ko/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ko/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "회원가입",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "회사 이메일",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "비밀번호",

--- a/app/javascript/dashboard/i18n/locale/lt/login.json
+++ b/app/javascript/dashboard/i18n/locale/lt/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "El. paštas",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/lt/signup.json
+++ b/app/javascript/dashboard/i18n/locale/lt/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registras",
     "TESTIMONIAL_HEADER": "Tereikia vieno žingsnio, kad judėtume į priekį",
     "TESTIMONIAL_CONTENT": "Liko vienas žingsnis, kad įtrauktumėte savo klientus, išlaikytumėte juos ir rastumėte naujų.",
-    "TERMS_ACCEPT": "Kurdami paskyrą sutinkate su mūsų <a href=\"https://www.chatwoot.com/terms\">T & C</a> ir <a href=\"https://www.chatwoot.com/ privacy-policy\">Privatumo politika</a>",
+    "TERMS_ACCEPT": "Kurdami paskyrą sutinkate su mūsų <a href=\"https://getcruisecontrol.com/terms\">T & C</a> ir <a href=\"https://getcruisecontrol.com/ privacy-policy\">Privatumo politika</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Užsiregistruoti su Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Darbinis el. paštas",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "Slaptažodis",

--- a/app/javascript/dashboard/i18n/locale/lv/login.json
+++ b/app/javascript/dashboard/i18n/locale/lv/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "E-pasts",
       "PLACEHOLDER": "piemers{'@'}firmasnosaukums.com",

--- a/app/javascript/dashboard/i18n/locale/lv/signup.json
+++ b/app/javascript/dashboard/i18n/locale/lv/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Reģistrēt",
     "TESTIMONIAL_HEADER": "Viss, kas nepieciešams, ir viens solis, lai virzītos uz priekšu",
     "TESTIMONIAL_CONTENT": "Jūs esat viena soļa attālumā no klientu piesaistīšanas, noturēšanas un jaunu klientu atrašanas.",
-    "TERMS_ACCEPT": "Izveidojot kontu, Jūs piekrītat mūsu <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privātuma politikai</a>",
+    "TERMS_ACCEPT": "Izveidojot kontu, Jūs piekrītat mūsu <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privātuma politikai</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Reģistrēties, izmantojot Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Darba e-pasts",
-      "PLACEHOLDER": "Ievadiet savu darba e-pasta adresi. Piemēram, bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Lūdzu, ievadiet derīgu darba e-pasta adresi."
+      "PLACEHOLDER": "Ievadiet savu darba adresi. Piemēram, bruce{'@'}wayne{'.'}enterprises",
+      "ERROR": "Lūdzu, ievadiet derīgu darba adresi."
     },
     "PASSWORD": {
       "LABEL": "Parole",

--- a/app/javascript/dashboard/i18n/locale/ml/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ml/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "രജിസ്റ്റർ",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "പാസ്‌വേഡ്",

--- a/app/javascript/dashboard/i18n/locale/ms/login.json
+++ b/app/javascript/dashboard/i18n/locale/ms/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/ms/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ms/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "Password",

--- a/app/javascript/dashboard/i18n/locale/ne/login.json
+++ b/app/javascript/dashboard/i18n/locale/ne/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/ne/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ne/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "Password",

--- a/app/javascript/dashboard/i18n/locale/nl/signup.json
+++ b/app/javascript/dashboard/i18n/locale/nl/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registreren",
     "TESTIMONIAL_HEADER": "Er is maar één stap nodig om vooruit te komen",
     "TESTIMONIAL_CONTENT": "U bent één stap verwijderd van het communiceren met uw klanten, ze te behouden en nieuwe te vinden.",
-    "TERMS_ACCEPT": "Door het aanmaken van een account, gaat u akkoord met onze <a href=\"https://www.chatwoot.com/terms\">T & C</a> en <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "Door het aanmaken van een account, gaat u akkoord met onze <a href=\"https://getcruisecontrol.com/terms\">T & C</a> en <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Registreren met Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Werk e-mail",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "Wachtwoord",

--- a/app/javascript/dashboard/i18n/locale/no/signup.json
+++ b/app/javascript/dashboard/i18n/locale/no/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registrer",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Bedriftse-postadresse",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "Passord",

--- a/app/javascript/dashboard/i18n/locale/pl/signup.json
+++ b/app/javascript/dashboard/i18n/locale/pl/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Rejestracja",
     "TESTIMONIAL_HEADER": "Wszystko czego potrzebujesz to jeden krok do przodu",
     "TESTIMONIAL_CONTENT": "Jesteś tylko jeden krok od zaangażowania swoich klientów, zatrzymania ich i znalezienia nowych.",
-    "TERMS_ACCEPT": "Tworząc konto, zgadzasz się na nasze <a href=\"https://www.chatwoot.com/terms\">Warunki korzystania</a> i <a href=\"https://www.chatwoot.com/privacy-policy\">Politykę prywatności</a>",
+    "TERMS_ACCEPT": "Tworząc konto, zgadzasz się na nasze <a href=\"https://getcruisecontrol.com/terms\">Warunki korzystania</a> i <a href=\"https://getcruisecontrol.com/privacy-policy\">Politykę prywatności</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Zarejestruj się za pomocą Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "E-mail służbowy",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Wprowadź poprawny adres e-mail służbowy"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Wprowadź poprawny adres e-mail"
     },
     "PASSWORD": {
       "LABEL": "Hasło",

--- a/app/javascript/dashboard/i18n/locale/pt/signup.json
+++ b/app/javascript/dashboard/i18n/locale/pt/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Cadastrar",
     "TESTIMONIAL_HEADER": "Tudo que precisa é um passo para avançar",
     "TESTIMONIAL_CONTENT": "Está a um passo de fidelizar os seus clientes, mantê-los e encontrar novos.",
-    "TERMS_ACCEPT": "Ao criar uma conta, concorda com os nossos <a href=\"https://www.chatwoot.com/terms\">Termos & Condições</a> e <a href=\"https://www.chatwoot.com/privacy-policy\">Política de privacidade</a>",
+    "TERMS_ACCEPT": "Ao criar uma conta, concorda com os nossos <a href=\"https://getcruisecontrol.com/terms\">Termos & Condições</a> e <a href=\"https://getcruisecontrol.com/privacy-policy\">Política de privacidade</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Inscrever-se com conta Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "E-mail de trabalho",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address"
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address"
     },
     "PASSWORD": {
       "LABEL": "Palavra-passe",

--- a/app/javascript/dashboard/i18n/locale/pt_BR/signup.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registrar",
     "TESTIMONIAL_HEADER": "Tudo o que ele leva é um passo para avançar",
     "TESTIMONIAL_CONTENT": "Você está a um passo de engajar seus clientes, mantê-los e encontrar novos.",
-    "TERMS_ACCEPT": "Ao criar uma conta, você concorda com nosso <a href=\"https://www.chatwoot.com/terms\">T & C</a> e nossa <a href=\"https://www.chatwoot.com/privacy-policy\">Política de privacidade</a>",
+    "TERMS_ACCEPT": "Ao criar uma conta, você concorda com nosso <a href=\"https://getcruisecontrol.com/terms\">T & C</a> e nossa <a href=\"https://getcruisecontrol.com/privacy-policy\">Política de privacidade</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Cadastre-se com o Google"
     },
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "E-mail comercial",
-      "PLACEHOLDER": "Digite seu endereço de e-mail de trabalho. Ex: bruce{'@'}wayne{'.'}empresas",
+      "PLACEHOLDER": "Digite seu endereço de e-mail de trabalho. Ex: bruce{'@'}example{'.'}com",
       "ERROR": "Por favor, insira um endereço de e-mail de trabalho válido."
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/ro/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ro/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Inregistrare",
     "TESTIMONIAL_HEADER": "Tot ce trebuie este un pas pentru a merge mai departe",
     "TESTIMONIAL_CONTENT": "Ești la un pas de a-ți angaja clienții, de a-i păstra și de a găsi altele noi.",
-    "TERMS_ACCEPT": "Prin crearea unui cont, sunteți de acord cu <a href=\"https://www.chatwoot.com/terms\">T & C</a> și <a href=\"https://www.chatwoot.com/privacy-policy\">politica noastră de confidențialitate</a>",
+    "TERMS_ACCEPT": "Prin crearea unui cont, sunteți de acord cu <a href=\"https://getcruisecontrol.com/terms\">T & C</a> și <a href=\"https://getcruisecontrol.com/privacy-policy\">politica noastră de confidențialitate</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Înscrieți-vă cu Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "E-mail de lucru",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Vă rugăm să introduceți o adresă de e-mail validă de lucru."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Vă rugăm să introduceți o adresă de e-mail validă."
     },
     "PASSWORD": {
       "LABEL": "Parola",

--- a/app/javascript/dashboard/i18n/locale/ru/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ru/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Регистрация",
     "TESTIMONIAL_HEADER": "Все, что нужно сделать, это один шаг для продвижения вперед",
     "TESTIMONIAL_CONTENT": "Вы находитесь на расстоянии всего одного шага от привлечения своих клиентов, удержав их и находя новые.",
-    "TERMS_ACCEPT": "Создавая учетную запись, вы соглашаетесь с нашими <a href=\"https://www.chatwoot.com/terms\">Т и С</a> и <a href=\"https://www.chatwoot.com/privacy-policy\">политикой конфиденциальности</a>",
+    "TERMS_ACCEPT": "Создавая учетную запись, вы соглашаетесь с нашими <a href=\"https://getcruisecontrol.com/terms\">Т и С</a> и <a href=\"https://getcruisecontrol.com/privacy-policy\">политикой конфиденциальности</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Регистрация через Google"
     },
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Рабочий email",
-      "PLACEHOLDER": "Введите ваш рабочий адрес электронной почты. Например: bruce{'@'}wayne{'.'}enterprises",
+      "PLACEHOLDER": "Введите ваш адрес электронной почты. Например: bruce{'@'}example{'.'}com",
       "ERROR": "Пожалуйста, введите действительный адрес электронной почты."
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/sh/login.json
+++ b/app/javascript/dashboard/i18n/locale/sh/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/sh/signup.json
+++ b/app/javascript/dashboard/i18n/locale/sh/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address."
     },
     "PASSWORD": {
       "LABEL": "Password",

--- a/app/javascript/dashboard/i18n/locale/sk/login.json
+++ b/app/javascript/dashboard/i18n/locale/sk/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/sk/signup.json
+++ b/app/javascript/dashboard/i18n/locale/sk/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registrovať",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Pracovný e-mail",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address."
     },
     "PASSWORD": {
       "LABEL": "Heslo",

--- a/app/javascript/dashboard/i18n/locale/sl/login.json
+++ b/app/javascript/dashboard/i18n/locale/sl/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "E-pošta",
       "PLACEHOLDER": "primer{'@'}imepodjetja.com",

--- a/app/javascript/dashboard/i18n/locale/sl/signup.json
+++ b/app/javascript/dashboard/i18n/locale/sl/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registrirajte se",
     "TESTIMONIAL_HEADER": "Le še en korak, da napredujete",
     "TESTIMONIAL_CONTENT": "Ste le korak stran od tega, da pritegnete svoje stranke, jih obdržite in najdete nove.",
-    "TERMS_ACCEPT": "Z ustvarjanjem računa se strinjate z našimi <a href=\"https://www.chatwoot.com/terms\">Pogoji uporabe</a> in z <a href=\"https://www.chatwoot.com/privacy-policy\">Politiko zasebnosti</a>",
+    "TERMS_ACCEPT": "Z ustvarjanjem računa se strinjate z našimi <a href=\"https://getcruisecontrol.com/terms\">Pogoji uporabe</a> in z <a href=\"https://getcruisecontrol.com/privacy-policy\">Politiko zasebnosti</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Prijavite se z Googlom"
     },
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Službena e-pošta",
-      "PLACEHOLDER": "Vnesite svoj službeni e-poštni naslov. Npr. bruce{'@'}wayne{'.'}enterprises",
+      "PLACEHOLDER": "Vnesite svoj službeni e-poštni naslov. Npr. bruce{'@'}example{'.'}com",
       "ERROR": "Vnesite veljaven službeni e-poštni naslov."
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/sq/login.json
+++ b/app/javascript/dashboard/i18n/locale/sq/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/sq/signup.json
+++ b/app/javascript/dashboard/i18n/locale/sq/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address."
     },
     "PASSWORD": {
       "LABEL": "Password",

--- a/app/javascript/dashboard/i18n/locale/sr/login.json
+++ b/app/javascript/dashboard/i18n/locale/sr/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "E-pošta",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/sr/signup.json
+++ b/app/javascript/dashboard/i18n/locale/sr/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registruj",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Poslovna e-pošta",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address."
     },
     "PASSWORD": {
       "LABEL": "Lozinka",

--- a/app/javascript/dashboard/i18n/locale/sv/signup.json
+++ b/app/javascript/dashboard/i18n/locale/sv/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Registrera",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "E-postadress, arbete",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address."
     },
     "PASSWORD": {
       "LABEL": "Lösenord",

--- a/app/javascript/dashboard/i18n/locale/ta/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ta/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "பதியவும்",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address."
     },
     "PASSWORD": {
       "LABEL": "பாஸ்வேர்ட்",

--- a/app/javascript/dashboard/i18n/locale/th/login.json
+++ b/app/javascript/dashboard/i18n/locale/th/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "อีเมล์",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/th/signup.json
+++ b/app/javascript/dashboard/i18n/locale/th/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "สร้างบัญชี",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "อีเมลบริษัท",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address."
     },
     "PASSWORD": {
       "LABEL": "หรัสผ่าน",

--- a/app/javascript/dashboard/i18n/locale/tl/login.json
+++ b/app/javascript/dashboard/i18n/locale/tl/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/tl/signup.json
+++ b/app/javascript/dashboard/i18n/locale/tl/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address."
     },
     "PASSWORD": {
       "LABEL": "Password",

--- a/app/javascript/dashboard/i18n/locale/tr/signup.json
+++ b/app/javascript/dashboard/i18n/locale/tr/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Kayıt ol",
     "TESTIMONIAL_HEADER": "İlerlemek için tek bir adım atmanız yeterlidir",
     "TESTIMONIAL_CONTENT": "Müşterilerinizle etkileşimde bulunmaktan, onları elde tutmaktan ve yeni müşteriler bulmaktan sadece bir adım uzaktasınız.",
-    "TERMS_ACCEPT": "Bir hesap oluşturarak, <a href=\"https://www.chatwoot.com/terms\">Kullanım Koşulları</a> ve <a href=\"https://www.chatwoot.com/privacy-policy\">Gizlilik Politikamızı</a> kabul etmiş olursunuz",
+    "TERMS_ACCEPT": "Bir hesap oluşturarak, <a href=\"https://getcruisecontrol.com/terms\">Kullanım Koşulları</a> ve <a href=\"https://getcruisecontrol.com/privacy-policy\">Gizlilik Politikamızı</a> kabul etmiş olursunuz",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Google ile kaydol"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "İş emaili",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Lütfen geçerli bir iş email adresi girin."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Lütfen geçerli bir email adresi girin."
     },
     "PASSWORD": {
       "LABEL": "Parola",

--- a/app/javascript/dashboard/i18n/locale/uk/signup.json
+++ b/app/javascript/dashboard/i18n/locale/uk/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Реєстрація",
     "TESTIMONIAL_HEADER": "Один крок і вперед",
     "TESTIMONIAL_CONTENT": "Ви за один крок від залучення своїх клієнтів, утримання їх та пошуку нових.",
-    "TERMS_ACCEPT": "Зареєструвавшись, ви погоджуєтеся з нашими <a href=\"https://www.chatwoot.com/terms\">Умовами Користування</a> та <a href=\"https://www.chatwoot.com/privacy-policy\">Політикою конфіденційності</a>",
+    "TERMS_ACCEPT": "Зареєструвавшись, ви погоджуєтеся з нашими <a href=\"https://getcruisecontrol.com/terms\">Умовами Користування</a> та <a href=\"https://getcruisecontrol.com/privacy-policy\">Політикою конфіденційності</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Зареєструватися через Google"
     },
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "Робоча електронна пошта",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
       "ERROR": "Будь ласка, введіть робочу адресу електронної пошти."
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/ur/login.json
+++ b/app/javascript/dashboard/i18n/locale/ur/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/ur/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ur/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address."
     },
     "PASSWORD": {
       "LABEL": "Password",

--- a/app/javascript/dashboard/i18n/locale/ur_IN/login.json
+++ b/app/javascript/dashboard/i18n/locale/ur_IN/login.json
@@ -1,6 +1,6 @@
 {
   "LOGIN": {
-    "TITLE": "Login to Chatwoot",
+    "TITLE": "Login to Cruise Control",
     "EMAIL": {
       "LABEL": "Email",
       "PLACEHOLDER": "example{'@'}companyname.com",

--- a/app/javascript/dashboard/i18n/locale/ur_IN/signup.json
+++ b/app/javascript/dashboard/i18n/locale/ur_IN/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Register",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Work email",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address."
     },
     "PASSWORD": {
       "LABEL": "Password",

--- a/app/javascript/dashboard/i18n/locale/vi/signup.json
+++ b/app/javascript/dashboard/i18n/locale/vi/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "Đăng kí",
     "TESTIMONIAL_HEADER": "Tất cả chỉ cần một bước để tiến về phía trước",
     "TESTIMONIAL_CONTENT": "Bạn chỉ còn một bước nữa là có thể thu hút khách hàng của mình, giữ chân họ và tìm kiếm những khách hàng mới.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "Email công việc",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Vui lòng nhập địa chỉ email công việc hợp lệ."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Vui lòng nhập địa chỉ email hợp lệ."
     },
     "PASSWORD": {
       "LABEL": "Mật khẩu",

--- a/app/javascript/dashboard/i18n/locale/zh/signup.json
+++ b/app/javascript/dashboard/i18n/locale/zh/signup.json
@@ -2,7 +2,7 @@
   "REGISTER": {
     "TRY_WOOT": "注册帐户",
     "TITLE": "注册",
-    "TERMS_ACCEPT": "通过注册，您同意我们的 <a href=\"https://www.chatwoot.com/terms\">T & C</a> 和 <a href=\"https://www.chatwoot.com/privacy-policy\">隐私政策</a>",
+    "TERMS_ACCEPT": "通过注册，您同意我们的 <a href=\"https://getcruisecontrol.com/terms\">T & C</a> 和 <a href=\"https://getcruisecontrol.com/privacy-policy\">隐私政策</a>",
     "ACCOUNT_NAME": {
       "LABEL": "帐户名称",
       "PLACEHOLDER": "Wayne企业",
@@ -10,7 +10,7 @@
     },
     "EMAIL": {
       "LABEL": "Email",
-      "PLACEHOLDER": "bruce{'@'}wayne{'.'}enterprises",
+      "PLACEHOLDER": "bruce{'@'}example{'.'}com",
       "ERROR": "电子邮件无效"
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/zh_CN/signup.json
+++ b/app/javascript/dashboard/i18n/locale/zh_CN/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "注册",
     "TESTIMONIAL_HEADER": "只差最后一步就可以了",
     "TESTIMONIAL_CONTENT": "您离吸引客户、留住客户和寻找新客户仅一步之遥。",
-    "TERMS_ACCEPT": "通过创建账户, 你将同意我们的 <a href=\"https://www.chatwoot.com/terms\">T & C</a> 以及 <a href=\"https://www.chatwoot.com/privacy-policy\">隐私政策</a>",
+    "TERMS_ACCEPT": "通过创建账户, 你将同意我们的 <a href=\"https://getcruisecontrol.com/terms\">T & C</a> 以及 <a href=\"https://getcruisecontrol.com/privacy-policy\">隐私政策</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "使用 Google 注册"
     },
@@ -20,7 +20,7 @@
     },
     "EMAIL": {
       "LABEL": "工作邮箱",
-      "PLACEHOLDER": "请输入您的工作邮箱地址。例如：bruce{'@'}wayne{'.'}enterprises",
+      "PLACEHOLDER": "请输入您的工作邮箱地址。例如：bruce{'@'}example{'.'}com",
       "ERROR": "请输入一个有效的电子邮件."
     },
     "PASSWORD": {

--- a/app/javascript/dashboard/i18n/locale/zh_TW/signup.json
+++ b/app/javascript/dashboard/i18n/locale/zh_TW/signup.json
@@ -4,7 +4,7 @@
     "TITLE": "註冊",
     "TESTIMONIAL_HEADER": "All it takes is one step to move forward",
     "TESTIMONIAL_CONTENT": "You're one step away from engaging your customers, retaining them and finding new ones.",
-    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://www.chatwoot.com/terms\">T & C</a> and <a href=\"https://www.chatwoot.com/privacy-policy\">Privacy policy</a>",
+    "TERMS_ACCEPT": "By creating an account, you agree to our <a href=\"https://getcruisecontrol.com/terms\">T & C</a> and <a href=\"https://getcruisecontrol.com/privacy-policy\">Privacy policy</a>",
     "OAUTH": {
       "GOOGLE_SIGNUP": "Sign up with Google"
     },
@@ -20,8 +20,8 @@
     },
     "EMAIL": {
       "LABEL": "工作電子郵件",
-      "PLACEHOLDER": "Enter your work email address. E.g., bruce{'@'}wayne{'.'}enterprises",
-      "ERROR": "Please enter a valid work email address."
+      "PLACEHOLDER": "Enter your email address. E.g., bruce{'@'}example{'.'}com",
+      "ERROR": "Please enter a valid email address."
     },
     "PASSWORD": {
       "LABEL": "密碼",

--- a/app/javascript/v3/views/auth/signup/components/Signup/Form.vue
+++ b/app/javascript/v3/views/auth/signup/components/Signup/Form.vue
@@ -11,7 +11,6 @@ import SubmitButton from '../../../../../components/Button/SubmitButton.vue';
 import { isValidPassword } from 'shared/helpers/Validators';
 import GoogleOAuthButton from '../../../../../components/GoogleOauth/Button.vue';
 import { register } from '../../../../../api/auth';
-import * as CompanyEmailValidator from 'company-email-validator';
 
 export default {
   components: {
@@ -52,9 +51,6 @@ export default {
         email: {
           required,
           email,
-          businessEmailValidator(value) {
-            return CompanyEmailValidator.isCompanyEmail(value);
-          },
         },
         password: {
           required,
@@ -68,9 +64,12 @@ export default {
     ...mapGetters({ globalConfig: 'globalConfig/get' }),
     termsLink() {
       return this.$t('REGISTER.TERMS_ACCEPT')
-        .replace('https://www.chatwoot.com/terms', this.globalConfig.termsURL)
         .replace(
-          'https://www.chatwoot.com/privacy-policy',
+          'https://getcruisecontrol.com/terms',
+          this.globalConfig.termsURL
+        )
+        .replace(
+          'https://getcruisecontrol.com/privacy-policy',
           this.globalConfig.privacyURL
         );
     },

--- a/app/views/installation/onboarding/index.html.erb
+++ b/app/views/installation/onboarding/index.html.erb
@@ -46,7 +46,7 @@
                   Work Email
                 </label>
                 <div class="mt-1">
-                  <%= email_field :user, :email, placeholder: "Enter your work email address. eg: bruce@wayne.enterprises", required: true, class: "block w-full rounded-md border-0 px-3 py-3 appearance-none shadow-sm ring-1 ring-inset text-slate-900 dark:text-slate-100 placeholder:text-slate-400 focus:ring-2 focus:ring-inset focus:ring-woot-500 sm:text-sm sm:leading-6 outline-none dark:bg-slate-700 dark:ring-slate-600 dark:focus:ring-woot-500 ring-slate-200" %>
+                  <%= email_field :user, :email, placeholder: "Enter your email address. eg: bruce@example.com", required: true, class: "block w-full rounded-md border-0 px-3 py-3 appearance-none shadow-sm ring-1 ring-inset text-slate-900 dark:text-slate-100 placeholder:text-slate-400 focus:ring-2 focus:ring-inset focus:ring-woot-500 sm:text-sm sm:leading-6 outline-none dark:bg-slate-700 dark:ring-slate-600 dark:focus:ring-woot-500 ring-slate-200" %>
                 </div>
               </div>
 

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -42,11 +42,11 @@
   display_title: 'Brand Name'
   description: 'The name that would be used in emails and the widget'
 - name: TERMS_URL
-  value: 'https://www.chatwoot.com/terms-of-service'
+  value: 'https://getcruisecontrol.com/terms-of-service'
   display_title: 'Terms URL'
   description: 'The terms of service URL displayed in Signup Page'
 - name: PRIVACY_URL
-  value: 'https://www.chatwoot.com/privacy-policy'
+  value: 'https://getcruisecontrol.com/privacy-policy'
   display_title: 'Privacy URL'
   description: 'The privacy policy URL displayed in the app'
 - name: DISPLAY_MANIFEST

--- a/enterprise/LICENSE
+++ b/enterprise/LICENSE
@@ -6,7 +6,7 @@ With regard to the Chatwoot Software:
 This software and associated documentation files (the "Software") may only be
 used in production, if you (and any entity that you represent) have agreed to,
 and are in compliance with, the Chatwoot Subscription Terms of Service, available
-at https://www.chatwoot.com/terms-of-service/ (the “Enterprise Terms”), or other
+at https://getcruisecontrol.com/terms-of-service/ (the “Enterprise Terms”), or other
 agreement governing the use of the Software, as agreed by you and Chatwoot,
 and otherwise have a valid Chatwoot Enterprise License for the
 correct number of user seats. Subject to the foregoing sentence, you are free to

--- a/enterprise/config/premium_installation_config.yml
+++ b/enterprise/config/premium_installation_config.yml
@@ -14,9 +14,9 @@
 - name: BRAND_NAME
   value: 'Chatwoot'
 - name: TERMS_URL
-  value: 'https://www.chatwoot.com/terms-of-service'
+  value: 'https://getcruisecontrol.com/terms-of-service'
 - name: PRIVACY_URL
-  value: 'https://www.chatwoot.com/privacy-policy'
+  value: 'https://getcruisecontrol.com/privacy-policy'
 - name: DISPLAY_MANIFEST
   value: true
 # ------- End of Branding Related Config ------- #

--- a/swagger/index.yml
+++ b/swagger/index.yml
@@ -3,7 +3,7 @@ info:
   description: This is the API documentation for Chatwoot server.
   version: 1.0.0
   title: Chatwoot
-  termsOfService:	https://www.chatwoot.com/terms-of-service/
+  termsOfService:	https://getcruisecontrol.com/terms-of-service/
   contact:
     email: hello@chatwoot.com
   license:

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -4,7 +4,7 @@
     "description": "This is the API documentation for Chatwoot server.",
     "version": "1.0.0",
     "title": "Chatwoot",
-    "termsOfService": "https://www.chatwoot.com/terms-of-service/",
+    "termsOfService": "https://getcruisecontrol.com/terms-of-service/",
     "contact": {
       "email": "hello@chatwoot.com"
     },


### PR DESCRIPTION
## Description

Verified that the on boarding  process does already support both corporate domain emails (e.g., @example.com) and personal email addresses (e.g., Gmail, Hotmail, Yahoo). It was just required to change the text of placeholder to reflect the acceptance of both.

## Release Notes:
- Verified, both corporate and personal email addresses are accepted during account on-boarding.
- Updated the placeholder text to reflect the acceptance of both emails.