### PR TITLE
fix: CRUISE-97 - enable installation configs setting for edits for disable help center/integration settings and disable captain & stripe page from code-base

### DIFF
--- a/app/controllers/super_admin/installation_configs_controller.rb
+++ b/app/controllers/super_admin/installation_configs_controller.rb
@@ -9,7 +9,6 @@ class SuperAdmin::InstallationConfigsController < SuperAdmin::ApplicationControl
     new_values = params.dig(:installation_config, :value) || []
     formatted_new_values = format_new_values(new_values)
     updated_values = update_existing_values(@resource.value || [], formatted_new_values)
-    updated_values = update_existing_values(@resource.value || [], formatted_new_values)
 
     if @resource.update(value: updated_values)
       redirect_to super_admin_installation_config_path(@resource), notice: 'Updated successfully'

--- a/app/controllers/super_admin/installation_configs_controller.rb
+++ b/app/controllers/super_admin/installation_configs_controller.rb
@@ -3,10 +3,20 @@ class SuperAdmin::InstallationConfigsController < SuperAdmin::ApplicationControl
   # Overwrite any of the RESTful controller actions to implement custom behavior
   # For example, you may want to send an email after a foo is updated.
   #
-  # def update
-  #   super
-  #   send_foo_updated_email(requested_resource)
-  # end
+  #
+  def update
+    @resource = InstallationConfig.find(params[:id])
+    new_values = params.dig(:installation_config, :value) || []
+    formatted_new_values = format_new_values(new_values)
+    updated_values = update_existing_values(@resource.value || [], formatted_new_values)
+    updated_values = update_existing_values(@resource.value || [], formatted_new_values)
+
+    if @resource.update(value: updated_values)
+      redirect_to super_admin_installation_config_path(@resource), notice: 'Updated successfully'
+    else
+      render :edit
+    end
+  end
 
   # Override this method to specify custom lookup behavior.
   # This will be used to set the resource for the `show`, `edit`, and `update`
@@ -44,4 +54,37 @@ class SuperAdmin::InstallationConfigsController < SuperAdmin::ApplicationControl
 
   # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
   # for more information
+
+  private
+
+  # Format new values by extracting relevant data and applying boolean conversion where necessary
+  def format_new_values(new_values)
+    new_values.values.map do |value|
+      {
+        'name' => value['name'],
+        'display_name' => value['display_name'],
+        'enabled' => boolean_value(value['enabled']),
+        'help_url' => value['help_url'],
+        'premium' => boolean_value(value['premium']),
+        'deprecated' => boolean_value(value['deprecated']),
+        'chatwoot_internal' => boolean_value(value['chatwoot_internal'])
+      }.compact
+    end
+  end
+
+  # Convert string to boolean if it's a "true" or "false" string, else return the original value
+  def boolean_value(value)
+    return true if value == 'true'
+    return false if value == 'false'
+
+    value
+  end
+
+  # Update existing values by merging with formatted new values if names match
+  def update_existing_values(existing_values, formatted_new_values)
+    existing_values.map do |existing|
+      new_value = formatted_new_values.find { |v| v['name'] == existing['name'] }
+      new_value ? existing.merge(new_value) : existing
+    end
+  end
 end

--- a/app/views/fields/serialized_field/_form.html.erb
+++ b/app/views/fields/serialized_field/_form.html.erb
@@ -2,12 +2,13 @@
   <%= f.label field.attribute, class: "field-unit__label" %>
   <div class="field-unit__field">
     <% if field.array? %>
-      <% field.data.each do |sub_field| %>
-        <%= f.fields_for "#{field.attribute}[]", field.resource do |values_form| %>
+      <% existing_values = field.data.presence || [{}] %>
+      <% existing_values.each_with_index do |sub_field, index| %>
+        <%= f.fields_for "#{field.attribute}[#{index}]", field.resource do |values_form| %>
           <div class="field-unit">
             <% sub_field.each do |sf_key, sf_value| %>
               <%= values_form.label sf_key %>
-              <%= values_form.text_field sf_key, value: sf_value, disabled: true %>
+              <%= values_form.text_field sf_key, value: sf_value, name: "#{f.object_name}[#{field.attribute}][#{index}][#{sf_key}]" %>
             <% end %>
           </div>
         <% end %>
@@ -17,3 +18,4 @@
     <% end %>
   </div>
 </div>
+

--- a/app/views/super_admin/settings/show.html.erb
+++ b/app/views/super_admin/settings/show.html.erb
@@ -88,14 +88,6 @@
           <div class="visible <% if !attrs[:enabled] %> group-hover:invisible <% end %> flex items-center justify-center w-10 h-10 mb-2 border border-slate-100 border-solid text-slate-800 rounded-full">
             <svg width="20" height="20"><use xlink:href="#<%= attrs[:icon] %>" /></svg>
           </div>
-          <% if !attrs[:enabled] %>
-          <div class="flex h-9 absolute top-5 items-center invisible group-hover:visible">
-            <a href="#" target="_blank" rel="noopener noreferrer" class="flex gap-1 items-center bg-slate-100 h-9 hover:bg-slate-300 hover:text-n-slate-12 border border-solid border-slate-100 rounded text-n-slate-11 font-medium p-2">
-              <svg class="h-4 w-4" width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M13.209 3.103c-.495-1.004-1.926-1.004-2.421 0L8.43 7.88l-5.273.766c-1.107.161-1.55 1.522-.748 2.303l3.815 3.72-.9 5.25c-.19 1.103.968 1.944 1.959 1.424l4.715-2.48 4.716 2.48c.99.52 2.148-.32 1.96-1.424l-.902-5.25 3.816-3.72c.8-.78.359-2.142-.748-2.303l-5.273-.766-2.358-4.777ZM9.74 8.615l2.258-4.576 2.259 4.576a1.35 1.35 0 0 0 1.016.738l5.05.734-3.654 3.562a1.35 1.35 0 0 0-.388 1.195l.862 5.03-4.516-2.375a1.35 1.35 0 0 0-1.257 0l-4.516 2.374.862-5.029a1.35 1.35 0 0 0-.388-1.195l-3.654-3.562 5.05-.734c.44-.063.82-.34 1.016-.738ZM1.164 3.782a.75.75 0 0 0 .118 1.054l2.5 2a.75.75 0 1 0 .937-1.172l-2.5-2a.75.75 0 0 0-1.055.118Z" fill="currentColor"/><path d="M22.836 18.218a.75.75 0 0 0-.117-1.054l-2.5-2a.75.75 0 0 0-.938 1.172l2.5 2a.75.75 0 0 0 1.055-.117ZM1.282 17.164a.75.75 0 1 0 .937 1.172l2.5-2a.75.75 0 0 0-.937-1.172l-2.5 2ZM22.836 3.782a.75.75 0 0 1-.117 1.054l-2.5 2a.75.75 0 0 1-.938-1.172l2.5-2a.75.75 0 0 1 1.055.118Z"  fill="currentColor"/></svg>
-              <%# <span class="px-1">Upgrade now</span> %>
-            </a>
-          </div>
-          <% end %>
           <div class="flex items-center justify-between mb-1.5 mt-4">
             <div class="flex items-center gap-2">
               <h3 class="text-n-slate-12 font-medium"><%= attrs[:name] %></h3>

--- a/app/views/super_admin/settings/show.html.erb
+++ b/app/views/super_admin/settings/show.html.erb
@@ -90,9 +90,9 @@
           </div>
           <% if !attrs[:enabled] %>
           <div class="flex h-9 absolute top-5 items-center invisible group-hover:visible">
-            <a href="<%= ChatwootHub.billing_url %>" target="_blank" rel="noopener noreferrer" class="flex gap-1 items-center bg-slate-100 h-9 hover:bg-slate-300 hover:text-n-slate-12 border border-solid border-slate-100 rounded text-n-slate-11 font-medium p-2">
+            <a href="#" target="_blank" rel="noopener noreferrer" class="flex gap-1 items-center bg-slate-100 h-9 hover:bg-slate-300 hover:text-n-slate-12 border border-solid border-slate-100 rounded text-n-slate-11 font-medium p-2">
               <svg class="h-4 w-4" width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M13.209 3.103c-.495-1.004-1.926-1.004-2.421 0L8.43 7.88l-5.273.766c-1.107.161-1.55 1.522-.748 2.303l3.815 3.72-.9 5.25c-.19 1.103.968 1.944 1.959 1.424l4.715-2.48 4.716 2.48c.99.52 2.148-.32 1.96-1.424l-.902-5.25 3.816-3.72c.8-.78.359-2.142-.748-2.303l-5.273-.766-2.358-4.777ZM9.74 8.615l2.258-4.576 2.259 4.576a1.35 1.35 0 0 0 1.016.738l5.05.734-3.654 3.562a1.35 1.35 0 0 0-.388 1.195l.862 5.03-4.516-2.375a1.35 1.35 0 0 0-1.257 0l-4.516 2.374.862-5.029a1.35 1.35 0 0 0-.388-1.195l-3.654-3.562 5.05-.734c.44-.063.82-.34 1.016-.738ZM1.164 3.782a.75.75 0 0 0 .118 1.054l2.5 2a.75.75 0 1 0 .937-1.172l-2.5-2a.75.75 0 0 0-1.055.118Z" fill="currentColor"/><path d="M22.836 18.218a.75.75 0 0 0-.117-1.054l-2.5-2a.75.75 0 0 0-.938 1.172l2.5 2a.75.75 0 0 0 1.055-.117ZM1.282 17.164a.75.75 0 1 0 .937 1.172l2.5-2a.75.75 0 0 0-.937-1.172l-2.5 2ZM22.836 3.782a.75.75 0 0 1-.117 1.054l-2.5 2a.75.75 0 0 1-.938-1.172l2.5-2a.75.75 0 0 1 1.055.118Z"  fill="currentColor"/></svg>
-              <span class="px-1">Upgrade now</span>
+              <%# <span class="px-1">Upgrade now</span> %>
             </a>
           </div>
           <% end %>

--- a/config/features.yml
+++ b/config/features.yml
@@ -136,10 +136,10 @@
 - name: linear_integration
   display_name: Linear Integration
   enabled: false
-- name: captain_integration
-  display_name: Captain
-  enabled: false
-  premium: true
+# - name: captain_integration
+#   display_name: Captain
+#   enabled: false
+#   premium: true
 - name: custom_roles
   display_name: Custom Roles
   enabled: false

--- a/enterprise/app/helpers/super_admin/features.yml
+++ b/enterprise/app/helpers/super_admin/features.yml
@@ -1,12 +1,12 @@
 # TODO: Move this values to features.yml itself
 # No need to replicate the same values in two places
-captain:
-  name: 'Captain'
-  description: 'Enable AI-powered conversations with your customers.'
-  enabled: <%= (ChatwootHub.pricing_plan != 'community') %>
-  icon: 'icon-captain'
-  config_key: 'captain'
-  enterprise: true
+# captain:
+#   name: 'Captain'
+#   description: 'Enable AI-powered conversations with your customers.'
+#   enabled: <%= (ChatwootHub.pricing_plan != 'community') %>
+#   icon: 'icon-captain'
+#   config_key: 'captain'
+#   enterprise: true
 custom_branding:
   name: 'Custom Branding'
   description: 'Apply your own branding to this installation.'

--- a/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
+++ b/enterprise/app/services/enterprise/billing/handle_stripe_event_service.rb
@@ -66,7 +66,7 @@ class Enterprise::Billing::HandleStripeEventService
   end
 
   def features_to_update
-    %w[inbound_emails help_center campaigns team_management channel_twitter channel_facebook channel_email captain_integration]
+    %w[inbound_emails help_center campaigns team_management channel_twitter channel_facebook channel_email]
   end
 
   def subscription

--- a/enterprise/config/premium_features.yml
+++ b/enterprise/config/premium_features.yml
@@ -3,5 +3,4 @@
 - audit_logs
 - response_bot
 - sla
-- captain_integration
 - custom_roles


### PR DESCRIPTION
## Description

Enable the Installation config settings for edits to disable  Help center / Integration and other settings for accounts for super admin. Disable the  checkout from Stripe and hide Captain existence from code base. 

## Release Notes:
- Enable Installation config settings for edits for Super Admin.
- The Captain feature has been disabled from code-base.
- Removed Stripe checkout link from upgrade links!. 
