### PR TITLE
fix: CRUISE-89: replace chatwoot domain with courier. cruise control domain

### DIFF
--- a/app/javascript/dashboard/helper/specs/URLHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/URLHelper.spec.js
@@ -73,7 +73,7 @@ describe('#URL Helpers', () => {
 
   describe('isValidURL', () => {
     it('should return true if valid url is passed', () => {
-      expect(isValidURL('https://chatwoot.com')).toBe(true);
+      expect(isValidURL('https://courier.getcruisecontrol.com')).toBe(true);
     });
     it('should return false if invalid url is passed', () => {
       expect(isValidURL('alert.window')).toBe(false);
@@ -170,7 +170,9 @@ describe('#URL Helpers', () => {
 
   describe('hasValidAvatarUrl', () => {
     test('should return true for valid non-Gravatar URL', () => {
-      expect(hasValidAvatarUrl('https://chatwoot.com/avatar.jpg')).toBe(true);
+      expect(
+        hasValidAvatarUrl('https://courier.getcruisecontrol.com/avatar.jpg')
+      ).toBe(true);
     });
 
     test('should return false for a Gravatar URL (www.gravatar.com)', () => {

--- a/app/javascript/dashboard/helper/specs/URLHelper.spec.js
+++ b/app/javascript/dashboard/helper/specs/URLHelper.spec.js
@@ -73,7 +73,7 @@ describe('#URL Helpers', () => {
 
   describe('isValidURL', () => {
     it('should return true if valid url is passed', () => {
-      expect(isValidURL('https://courier.getcruisecontrol.com')).toBe(true);
+      expect(isValidURL('https://getcruisecontrol.com')).toBe(true);
     });
     it('should return false if invalid url is passed', () => {
       expect(isValidURL('alert.window')).toBe(false);
@@ -171,7 +171,7 @@ describe('#URL Helpers', () => {
   describe('hasValidAvatarUrl', () => {
     test('should return true for valid non-Gravatar URL', () => {
       expect(
-        hasValidAvatarUrl('https://courier.getcruisecontrol.com/avatar.jpg')
+        hasValidAvatarUrl('https://getcruisecontrol.com/avatar.jpg')
       ).toBe(true);
     });
 

--- a/app/javascript/dashboard/store/modules/specs/campaigns/fixtures.js
+++ b/app/javascript/dashboard/store/modules/specs/campaigns/fixtures.js
@@ -21,7 +21,7 @@ export default [
     account_id: 1,
     campaign_type: 'one_off',
     trigger_rules: {
-      url: 'https://courier.getcruisecontrol.com',
+      url: 'https://getcruisecontrol.com',
       time_on_page: '20',
     },
     created_at: '2021-05-03T08:15:35.828Z',

--- a/app/javascript/dashboard/store/modules/specs/campaigns/fixtures.js
+++ b/app/javascript/dashboard/store/modules/specs/campaigns/fixtures.js
@@ -21,7 +21,7 @@ export default [
     account_id: 1,
     campaign_type: 'one_off',
     trigger_rules: {
-      url: 'https://chatwoot.com',
+      url: 'https://courier.getcruisecontrol.com',
       time_on_page: '20',
     },
     created_at: '2021-05-03T08:15:35.828Z',

--- a/app/javascript/dashboard/store/modules/specs/campaigns/getters.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/campaigns/getters.spec.js
@@ -21,7 +21,7 @@ describe('#getters', () => {
         campaign_type: 'one_off',
 
         trigger_rules: {
-          url: 'https://courier.getcruisecontrol.com',
+          url: 'https://getcruisecontrol.com',
           time_on_page: '20',
         },
         created_at: '2021-05-03T08:15:35.828Z',

--- a/app/javascript/dashboard/store/modules/specs/campaigns/getters.spec.js
+++ b/app/javascript/dashboard/store/modules/specs/campaigns/getters.spec.js
@@ -21,7 +21,7 @@ describe('#getters', () => {
         campaign_type: 'one_off',
 
         trigger_rules: {
-          url: 'https://chatwoot.com',
+          url: 'https://courier.getcruisecontrol.com',
           time_on_page: '20',
         },
         created_at: '2021-05-03T08:15:35.828Z',

--- a/app/javascript/dashboard/store/modules/specs/dashboardApps/fixtures.js
+++ b/app/javascript/dashboard/store/modules/specs/dashboardApps/fixtures.js
@@ -2,7 +2,7 @@ export const payload = {
   title: 'Test',
   content: [
     { url: 'https://example.com', type: 'frame' },
-    { url: 'https://courier.getcruisecontrol.com', type: 'frame' },
+    { url: 'https://getcruisecontrol.com', type: 'frame' },
   ],
 };
 
@@ -12,7 +12,7 @@ export const automationsList = [
     title: 'Test',
     content: [
       { url: 'https://example.com', type: 'frame' },
-      { url: 'https://courier.getcruisecontrol.com', type: 'frame' },
+      { url: 'https://getcruisecontrol.com', type: 'frame' },
     ],
     created_at: '2022-06-27T08:28:29.841Z',
   },

--- a/app/javascript/dashboard/store/modules/specs/dashboardApps/fixtures.js
+++ b/app/javascript/dashboard/store/modules/specs/dashboardApps/fixtures.js
@@ -2,7 +2,7 @@ export const payload = {
   title: 'Test',
   content: [
     { url: 'https://example.com', type: 'frame' },
-    { url: 'https://chatwoot.com', type: 'frame' },
+    { url: 'https://courier.getcruisecontrol.com', type: 'frame' },
   ],
 };
 
@@ -12,7 +12,7 @@ export const automationsList = [
     title: 'Test',
     content: [
       { url: 'https://example.com', type: 'frame' },
-      { url: 'https://chatwoot.com', type: 'frame' },
+      { url: 'https://courier.getcruisecontrol.com', type: 'frame' },
     ],
     created_at: '2022-06-27T08:28:29.841Z',
   },

--- a/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
+++ b/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
@@ -17,10 +17,11 @@ describe('#MessageFormatter', () => {
       );
     });
     it('should not convert template variables to links when linkify is disabled', () => {
-      const message = 'Hey {{customer.name}}, check https://chatwoot.com';
+      const message =
+        'Hey {{customer.name}}, check https://courier.getcruisecontrol.com';
       const formatter = new MessageFormatter(message, false, false, false);
       expect(formatter.formattedMessage).toMatch(
-        '<p>Hey {{customer.name}}, check https://chatwoot.com</p>'
+        '<p>Hey {{customer.name}}, check https://courier.getcruisecontrol.com</p>'
       );
     });
   });

--- a/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
+++ b/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
@@ -4,24 +4,24 @@ describe('#MessageFormatter', () => {
   describe('content with links', () => {
     it('should format correctly', () => {
       const message =
-        'Chatwoot is an opensource tool. [Chatwoot](https://www.chatwoot.com)';
+        'Cruise Control is an opensource tool. [Cruise Control](https://getcruisecontrol.com)';
       expect(new MessageFormatter(message).formattedMessage).toMatch(
-        '<p>Chatwoot is an opensource tool. <a href="https://www.chatwoot.com" class="link" rel="noreferrer noopener nofollow" target="_blank">Chatwoot</a></p>'
+        '<p>Cruise Control is an opensource tool. <a href="https://getcruisecontrol.com" class="link" rel="noreferrer noopener nofollow" target="_blank">Cruise Control</a></p>'
       );
     });
     it('should format correctly', () => {
       const message =
-        'Chatwoot is an opensource tool. https://www.chatwoot.com';
+        'Cruise Control is an opensource tool. https://getcruisecontrol.com';
       expect(new MessageFormatter(message).formattedMessage).toMatch(
-        '<p>Chatwoot is an opensource tool. <a href="https://www.chatwoot.com" class="link" rel="noreferrer noopener nofollow" target="_blank">https://www.chatwoot.com</a></p>'
+        '<p>Cruise Control is an opensource tool. <a href="https://getcruisecontrol.com" class="link" rel="noreferrer noopener nofollow" target="_blank">https://getcruisecontrol.com</a></p>'
       );
     });
     it('should not convert template variables to links when linkify is disabled', () => {
       const message =
-        'Hey {{customer.name}}, check https://courier.getcruisecontrol.com';
+        'Hey {{customer.name}}, check https://getcruisecontrol.com';
       const formatter = new MessageFormatter(message, false, false, false);
       expect(formatter.formattedMessage).toMatch(
-        '<p>Hey {{customer.name}}, check https://courier.getcruisecontrol.com</p>'
+        '<p>Hey {{customer.name}}, check https://getcruisecontrol.com</p>'
       );
     });
   });
@@ -39,25 +39,25 @@ describe('#MessageFormatter', () => {
   describe('content with image and has "cw_image_height" query at the end of URL', () => {
     it('should set image height correctly', () => {
       const message =
-        'Chatwoot is an opensource tool. ![](http://chatwoot.com/chatwoot.png?cw_image_height=24px)';
+        'Cruise Control is an opensource tool. ![](http://chatwoot.com/chatwoot.png?cw_image_height=24px)';
       expect(new MessageFormatter(message).formattedMessage).toMatch(
-        '<p>Chatwoot is an opensource tool. <img src="http://chatwoot.com/chatwoot.png?cw_image_height=24px" alt="" style="height: 24px;" /></p>'
+        '<p>Cruise Control is an opensource tool. <img src="http://chatwoot.com/chatwoot.png?cw_image_height=24px" alt="" style="height: 24px;" /></p>'
       );
     });
 
     it('should set image height correctly if its original size', () => {
       const message =
-        'Chatwoot is an opensource tool. ![](http://chatwoot.com/chatwoot.png?cw_image_height=auto)';
+        'Cruise Control is an opensource tool. ![](http://chatwoot.com/chatwoot.png?cw_image_height=auto)';
       expect(new MessageFormatter(message).formattedMessage).toMatch(
-        '<p>Chatwoot is an opensource tool. <img src="http://chatwoot.com/chatwoot.png?cw_image_height=auto" alt="" style="height: auto;" /></p>'
+        '<p>Cruise Control is an opensource tool. <img src="http://chatwoot.com/chatwoot.png?cw_image_height=auto" alt="" style="height: auto;" /></p>'
       );
     });
 
     it('should not set height', () => {
       const message =
-        'Chatwoot is an opensource tool. ![](http://chatwoot.com/chatwoot.png)';
+        'Cruise Control is an opensource tool. ![](http://chatwoot.com/chatwoot.png)';
       expect(new MessageFormatter(message).formattedMessage).toMatch(
-        '<p>Chatwoot is an opensource tool. <img src="http://chatwoot.com/chatwoot.png" alt="" /></p>'
+        '<p>Cruise Control is an opensource tool. <img src="http://chatwoot.com/chatwoot.png" alt="" /></p>'
       );
     });
   });
@@ -113,9 +113,9 @@ describe('#MessageFormatter', () => {
   describe('plain text content', () => {
     it('returns the plain text without HTML', () => {
       const message =
-        '<b>Chatwoot is an opensource tool. https://www.chatwoot.com</b>';
+        '<b>Cruise Control is an opensource tool. https://getcruisecontrol.com</b>';
       expect(new MessageFormatter(message).plainText).toMatch(
-        'Chatwoot is an opensource tool. https://www.chatwoot.com'
+        'Cruise Control is an opensource tool. https://getcruisecontrol.com'
       );
     });
   });

--- a/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
+++ b/app/javascript/shared/helpers/specs/MessageFormatter.spec.js
@@ -39,25 +39,25 @@ describe('#MessageFormatter', () => {
   describe('content with image and has "cw_image_height" query at the end of URL', () => {
     it('should set image height correctly', () => {
       const message =
-        'Cruise Control is an opensource tool. ![](http://chatwoot.com/chatwoot.png?cw_image_height=24px)';
+        'Cruise Control is an opensource tool. ![](https://getcruisecontrol.com/chatwoot.png?cw_image_height=24px)';
       expect(new MessageFormatter(message).formattedMessage).toMatch(
-        '<p>Cruise Control is an opensource tool. <img src="http://chatwoot.com/chatwoot.png?cw_image_height=24px" alt="" style="height: 24px;" /></p>'
+        '<p>Cruise Control is an opensource tool. <img src="https://getcruisecontrol.com/chatwoot.png?cw_image_height=24px" alt="" style="height: 24px;" /></p>'
       );
     });
 
     it('should set image height correctly if its original size', () => {
       const message =
-        'Cruise Control is an opensource tool. ![](http://chatwoot.com/chatwoot.png?cw_image_height=auto)';
+        'Cruise Control is an opensource tool. ![](https://getcruisecontrol.com/chatwoot.png?cw_image_height=auto)';
       expect(new MessageFormatter(message).formattedMessage).toMatch(
-        '<p>Cruise Control is an opensource tool. <img src="http://chatwoot.com/chatwoot.png?cw_image_height=auto" alt="" style="height: auto;" /></p>'
+        '<p>Cruise Control is an opensource tool. <img src="https://getcruisecontrol.com/chatwoot.png?cw_image_height=auto" alt="" style="height: auto;" /></p>'
       );
     });
 
     it('should not set height', () => {
       const message =
-        'Cruise Control is an opensource tool. ![](http://chatwoot.com/chatwoot.png)';
+        'Cruise Control is an opensource tool. ![](https://getcruisecontrol.com/chatwoot.png)';
       expect(new MessageFormatter(message).formattedMessage).toMatch(
-        '<p>Cruise Control is an opensource tool. <img src="http://chatwoot.com/chatwoot.png" alt="" /></p>'
+        '<p>Cruise Control is an opensource tool. <img src="https://getcruisecontrol.com/chatwoot.png" alt="" /></p>'
       );
     });
   });

--- a/app/javascript/widget/helpers/specs/campaignFixtures.js
+++ b/app/javascript/widget/helpers/specs/campaignFixtures.js
@@ -4,7 +4,7 @@ export default [
     trigger_only_during_business_hours: false,
     trigger_rules: {
       time_on_page: 3,
-      url: 'https://www.chatwoot.com/pricing',
+      url: 'https://getcruisecontrol.com/pricing',
     },
   },
   {
@@ -12,7 +12,7 @@ export default [
     trigger_only_during_business_hours: false,
     trigger_rules: {
       time_on_page: 6,
-      url: 'https://www.chatwoot.com/about',
+      url: 'https://getcruisecontrol.com/about',
     },
   },
 ];

--- a/app/javascript/widget/helpers/specs/campaignHelper.spec.js
+++ b/app/javascript/widget/helpers/specs/campaignHelper.spec.js
@@ -13,8 +13,8 @@ describe('#Campaigns Helper', () => {
     it('returns correct value if a valid URL is passed', () => {
       expect(
         isPatternMatchingWithURL(
-          'https://chatwoot.com/pricing*',
-          'https://chatwoot.com/pricing/'
+          'https://courier.getcruisecontrol.com/pricing*',
+          'https://courier.getcruisecontrol.com/pricing/'
         )
       ).toBe(true);
 
@@ -35,7 +35,7 @@ describe('#Campaigns Helper', () => {
       expect(
         isPatternMatchingWithURL(
           'https://{*.}?chatwoot.com/pricing*\\?*',
-          'https://chatwoot.com/pricing/?test=true'
+          'https://courier.getcruisecontrol.com/pricing/?test=true'
         )
       ).toBe(true);
     });

--- a/app/javascript/widget/helpers/specs/campaignHelper.spec.js
+++ b/app/javascript/widget/helpers/specs/campaignHelper.spec.js
@@ -13,29 +13,29 @@ describe('#Campaigns Helper', () => {
     it('returns correct value if a valid URL is passed', () => {
       expect(
         isPatternMatchingWithURL(
-          'https://courier.getcruisecontrol.com/pricing*',
-          'https://courier.getcruisecontrol.com/pricing/'
+          'https://getcruisecontrol.com/pricing*',
+          'https://getcruisecontrol.com/pricing/'
         )
       ).toBe(true);
 
       expect(
         isPatternMatchingWithURL(
           'https://*.chatwoot.com/pricing/',
-          'https://app.chatwoot.com/pricing/'
+          'https://courier.getcruisecontrol.com/pricing/'
         )
       ).toBe(true);
 
       expect(
         isPatternMatchingWithURL(
           'https://{*.}?chatwoot.com/pricing?test=true',
-          'https://app.chatwoot.com/pricing/?test=true'
+          'https://courier.getcruisecontrol.com/pricing/?test=true'
         )
       ).toBe(true);
 
       expect(
         isPatternMatchingWithURL(
           'https://{*.}?chatwoot.com/pricing*\\?*',
-          'https://courier.getcruisecontrol.com/pricing/?test=true'
+          'https://getcruisecontrol.com/pricing/?test=true'
         )
       ).toBe(true);
     });
@@ -48,13 +48,13 @@ describe('#Campaigns Helper', () => {
           id: 1,
           timeOnPage: 3,
           triggerOnlyDuringBusinessHours: false,
-          url: 'https://www.chatwoot.com/pricing',
+          url: 'https://getcruisecontrol.com/pricing',
         },
         {
           id: 2,
           triggerOnlyDuringBusinessHours: false,
           timeOnPage: 6,
-          url: 'https://www.chatwoot.com/about',
+          url: 'https://getcruisecontrol.com/about',
         },
       ]);
     });
@@ -67,23 +67,23 @@ describe('#Campaigns Helper', () => {
             {
               id: 1,
               timeOnPage: 3,
-              url: 'https://www.chatwoot.com/pricing',
+              url: 'https://getcruisecontrol.com/pricing',
               triggerOnlyDuringBusinessHours: false,
             },
             {
               id: 2,
               timeOnPage: 6,
-              url: 'https://www.chatwoot.com/about',
+              url: 'https://getcruisecontrol.com/about',
               triggerOnlyDuringBusinessHours: false,
             },
           ],
-          currentURL: 'https://www.chatwoot.com/about/',
+          currentURL: 'https://getcruisecontrol.com/about/',
         })
       ).toStrictEqual([
         {
           id: 2,
           timeOnPage: 6,
-          url: 'https://www.chatwoot.com/about',
+          url: 'https://getcruisecontrol.com/about',
           triggerOnlyDuringBusinessHours: false,
         },
       ]);
@@ -95,24 +95,24 @@ describe('#Campaigns Helper', () => {
             {
               id: 1,
               timeOnPage: 3,
-              url: 'https://www.chatwoot.com/pricing',
+              url: 'https://getcruisecontrol.com/pricing',
               triggerOnlyDuringBusinessHours: false,
             },
             {
               id: 2,
               timeOnPage: 6,
-              url: 'https://www.chatwoot.com/about',
+              url: 'https://getcruisecontrol.com/about',
               triggerOnlyDuringBusinessHours: true,
             },
           ],
-          currentURL: 'https://www.chatwoot.com/about/',
+          currentURL: 'https://getcruisecontrol.com/about/',
           isInBusinessHours: true,
         })
       ).toStrictEqual([
         {
           id: 2,
           timeOnPage: 6,
-          url: 'https://www.chatwoot.com/about',
+          url: 'https://getcruisecontrol.com/about',
           triggerOnlyDuringBusinessHours: true,
         },
       ]);
@@ -124,17 +124,17 @@ describe('#Campaigns Helper', () => {
             {
               id: 1,
               timeOnPage: 3,
-              url: 'https://www.chatwoot.com/pricing',
+              url: 'https://getcruisecontrol.com/pricing',
               triggerOnlyDuringBusinessHours: true,
             },
             {
               id: 2,
               timeOnPage: 6,
-              url: 'https://www.chatwoot.com/about',
+              url: 'https://getcruisecontrol.com/about',
               triggerOnlyDuringBusinessHours: true,
             },
           ],
-          currentURL: 'https://www.chatwoot.com/about/',
+          currentURL: 'https://getcruisecontrol.com/about/',
           isInBusinessHours: false,
         })
       ).toStrictEqual([]);

--- a/app/javascript/widget/helpers/specs/campaignHelper.spec.js
+++ b/app/javascript/widget/helpers/specs/campaignHelper.spec.js
@@ -20,21 +20,21 @@ describe('#Campaigns Helper', () => {
 
       expect(
         isPatternMatchingWithURL(
-          'https://*.chatwoot.com/pricing/',
+          'https://*.getcruisecontrol.com/pricing/',
           'https://courier.getcruisecontrol.com/pricing/'
         )
       ).toBe(true);
 
       expect(
         isPatternMatchingWithURL(
-          'https://{*.}?chatwoot.com/pricing?test=true',
+          'https://{*.}?getcruisecontrol.com/pricing?test=true',
           'https://courier.getcruisecontrol.com/pricing/?test=true'
         )
       ).toBe(true);
 
       expect(
         isPatternMatchingWithURL(
-          'https://{*.}?chatwoot.com/pricing*\\?*',
+          'https://{*.}?getcruisecontrol.com/pricing*\\?*',
           'https://getcruisecontrol.com/pricing/?test=true'
         )
       ).toBe(true);

--- a/app/javascript/widget/helpers/specs/urlParamsHelper.spec.js
+++ b/app/javascript/widget/helpers/specs/urlParamsHelper.spec.js
@@ -39,13 +39,13 @@ describe('#buildPopoutURL', () => {
   it('returns popout URL', () => {
     expect(
       buildPopoutURL({
-        origin: 'https://courier.getcruisecontrol.com',
+        origin: 'https://getcruisecontrol.com',
         conversationCookie: 'random-jwt-token',
         websiteToken: 'random-website-token',
         locale: 'ar',
       })
     ).toEqual(
-      'https://courier.getcruisecontrol.com/widget?cw_conversation=random-jwt-token&website_token=random-website-token&locale=ar'
+      'https://getcruisecontrol.com/widget?cw_conversation=random-jwt-token&website_token=random-website-token&locale=ar'
     );
   });
 });

--- a/app/javascript/widget/helpers/specs/urlParamsHelper.spec.js
+++ b/app/javascript/widget/helpers/specs/urlParamsHelper.spec.js
@@ -39,13 +39,13 @@ describe('#buildPopoutURL', () => {
   it('returns popout URL', () => {
     expect(
       buildPopoutURL({
-        origin: 'https://chatwoot.com',
+        origin: 'https://courier.getcruisecontrol.com',
         conversationCookie: 'random-jwt-token',
         websiteToken: 'random-website-token',
         locale: 'ar',
       })
     ).toEqual(
-      'https://chatwoot.com/widget?cw_conversation=random-jwt-token&website_token=random-website-token&locale=ar'
+      'https://courier.getcruisecontrol.com/widget?cw_conversation=random-jwt-token&website_token=random-website-token&locale=ar'
     );
   });
 });

--- a/app/javascript/widget/store/modules/specs/campaign/actions.spec.js
+++ b/app/javascript/widget/store/modules/specs/campaign/actions.spec.js
@@ -21,7 +21,7 @@ describe('#actions', () => {
         { commit },
         {
           websiteToken: 'XDsafmADasd',
-          currentURL: 'https://chatwoot.com',
+          currentURL: 'https://courier.getcruisecontrol.com',
           isInBusinessHours: true,
         }
       );
@@ -35,7 +35,7 @@ describe('#actions', () => {
             {
               id: 11,
               timeOnPage: '20',
-              url: 'https://chatwoot.com',
+              url: 'https://courier.getcruisecontrol.com',
               triggerOnlyDuringBusinessHours: false,
             },
           ],
@@ -59,7 +59,7 @@ describe('#actions', () => {
   describe('#initCampaigns', () => {
     const actionParams = {
       websiteToken: 'XDsafmADasd',
-      currentURL: 'https://chatwoot.com',
+      currentURL: 'https://courier.getcruisecontrol.com',
     };
     it('sends correct actions if campaigns are empty', async () => {
       await actions.initCampaigns(
@@ -103,7 +103,7 @@ describe('#actions', () => {
             {
               id: 11,
               timeOnPage: '20',
-              url: 'https://chatwoot.com',
+              url: 'https://courier.getcruisecontrol.com',
               triggerOnlyDuringBusinessHours: false,
             },
           ],

--- a/app/javascript/widget/store/modules/specs/campaign/actions.spec.js
+++ b/app/javascript/widget/store/modules/specs/campaign/actions.spec.js
@@ -21,7 +21,7 @@ describe('#actions', () => {
         { commit },
         {
           websiteToken: 'XDsafmADasd',
-          currentURL: 'https://courier.getcruisecontrol.com',
+          currentURL: 'https://getcruisecontrol.com',
           isInBusinessHours: true,
         }
       );
@@ -35,7 +35,7 @@ describe('#actions', () => {
             {
               id: 11,
               timeOnPage: '20',
-              url: 'https://courier.getcruisecontrol.com',
+              url: 'https://getcruisecontrol.com',
               triggerOnlyDuringBusinessHours: false,
             },
           ],
@@ -49,7 +49,7 @@ describe('#actions', () => {
         { commit },
         {
           websiteToken: 'XDsafmADasd',
-          currentURL: 'https://www.chatwoot.com',
+          currentURL: 'https://getcruisecontrol.com',
           isInBusinessHours: true,
         }
       );
@@ -59,7 +59,7 @@ describe('#actions', () => {
   describe('#initCampaigns', () => {
     const actionParams = {
       websiteToken: 'XDsafmADasd',
-      currentURL: 'https://courier.getcruisecontrol.com',
+      currentURL: 'https://getcruisecontrol.com',
     };
     it('sends correct actions if campaigns are empty', async () => {
       await actions.initCampaigns(
@@ -103,7 +103,7 @@ describe('#actions', () => {
             {
               id: 11,
               timeOnPage: '20',
-              url: 'https://courier.getcruisecontrol.com',
+              url: 'https://getcruisecontrol.com',
               triggerOnlyDuringBusinessHours: false,
             },
           ],

--- a/app/javascript/widget/store/modules/specs/campaign/data.js
+++ b/app/javascript/widget/store/modules/specs/campaign/data.js
@@ -50,7 +50,7 @@ export const campaigns = [
     message: 'Begin your onboarding campaign with a welcome message',
     enabled: true,
     trigger_rules: {
-      url: 'https://courier.getcruisecontrol.com',
+      url: 'https://getcruisecontrol.com',
       time_on_page: '20',
     },
     created_at: '2021-05-03T08:15:35.828Z',

--- a/app/javascript/widget/store/modules/specs/campaign/data.js
+++ b/app/javascript/widget/store/modules/specs/campaign/data.js
@@ -50,7 +50,7 @@ export const campaigns = [
     message: 'Begin your onboarding campaign with a welcome message',
     enabled: true,
     trigger_rules: {
-      url: 'https://chatwoot.com',
+      url: 'https://courier.getcruisecontrol.com',
       time_on_page: '20',
     },
     created_at: '2021-05-03T08:15:35.828Z',

--- a/app/javascript/widget/store/modules/specs/campaign/getters.spec.js
+++ b/app/javascript/widget/store/modules/specs/campaign/getters.spec.js
@@ -60,7 +60,7 @@ describe('#getters', () => {
         message: 'Begin your onboarding campaign with a welcome message',
         enabled: true,
         trigger_rules: {
-          url: 'https://courier.getcruisecontrol.com',
+          url: 'https://getcruisecontrol.com',
           time_on_page: '20',
         },
         created_at: '2021-05-03T08:15:35.828Z',

--- a/app/javascript/widget/store/modules/specs/campaign/getters.spec.js
+++ b/app/javascript/widget/store/modules/specs/campaign/getters.spec.js
@@ -60,7 +60,7 @@ describe('#getters', () => {
         message: 'Begin your onboarding campaign with a welcome message',
         enabled: true,
         trigger_rules: {
-          url: 'https://chatwoot.com',
+          url: 'https://courier.getcruisecontrol.com',
           time_on_page: '20',
         },
         created_at: '2021-05-03T08:15:35.828Z',

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -30,11 +30,11 @@
   display_title: 'Logo Dark Mode'
   description: 'The logo that would be used on the dashboard, login page etc. for dark mode'
 - name: BRAND_URL
-  value: 'https://courier.getcruisecontrol.com'
+  value: 'https://getcruisecontrol.com'
   display_title: 'Brand URL'
   description: 'The URL that would be used in emails under the section “Powered By”'
 - name: WIDGET_BRAND_URL
-  value: 'https://courier.getcruisecontrol.com'
+  value: 'https://getcruisecontrol.com'
   display_title: 'Widget Brand URL'
   description: 'The URL that would be used in the widget under the section “Powered By”'
 - name: BRAND_NAME
@@ -42,11 +42,11 @@
   display_title: 'Brand Name'
   description: 'The name that would be used in emails and the widget'
 - name: TERMS_URL
-  value: 'https://courier.getcruisecontrol.com/terms-of-service'
+  value: 'https://getcruisecontrol.com/terms-of-service'
   display_title: 'Terms URL'
   description: 'The terms of service URL displayed in Signup Page'
 - name: PRIVACY_URL
-  value: 'https://courier.getcruisecontrol.com/privacy-policy'
+  value: 'https://getcruisecontrol.com/privacy-policy'
   display_title: 'Privacy URL'
   description: 'The privacy policy URL displayed in the app'
 - name: DISPLAY_MANIFEST

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -30,11 +30,11 @@
   display_title: 'Logo Dark Mode'
   description: 'The logo that would be used on the dashboard, login page etc. for dark mode'
 - name: BRAND_URL
-  value: 'https://www.chatwoot.com'
+  value: 'https://courier.getcruisecontrol.com'
   display_title: 'Brand URL'
   description: 'The URL that would be used in emails under the section “Powered By”'
 - name: WIDGET_BRAND_URL
-  value: 'https://www.chatwoot.com'
+  value: 'https://courier.getcruisecontrol.com'
   display_title: 'Widget Brand URL'
   description: 'The URL that would be used in the widget under the section “Powered By”'
 - name: BRAND_NAME
@@ -42,11 +42,11 @@
   display_title: 'Brand Name'
   description: 'The name that would be used in emails and the widget'
 - name: TERMS_URL
-  value: 'https://www.chatwoot.com/terms-of-service'
+  value: 'https://courier.getcruisecontrol.com/terms-of-service'
   display_title: 'Terms URL'
   description: 'The terms of service URL displayed in Signup Page'
 - name: PRIVACY_URL
-  value: 'https://www.chatwoot.com/privacy-policy'
+  value: 'https://courier.getcruisecontrol.com/privacy-policy'
   display_title: 'Privacy URL'
   description: 'The privacy policy URL displayed in the app'
 - name: DISPLAY_MANIFEST

--- a/deployment/setup_20.04.sh
+++ b/deployment/setup_20.04.sh
@@ -451,7 +451,7 @@ function ssl_success_message() {
 Woot! Woot!! Chatwoot server installation is complete.
 The server will be accessible at https://$domain_name
 
-Join the community at https://courier.getcruisecontrol.com/community?utm_source=cwctl
+Join the community at https://getcruisecontrol.com/community?utm_source=cwctl
 ***************************************************************************
 
 EOF
@@ -563,7 +563,7 @@ The server will be accessible at http://$public_ip:3000
 To configure a domain and SSL certificate, follow the guide at
 https://www.chatwoot.com/docs/deployment/deploy-chatwoot-in-linux-vm?utm_source=cwctl
 
-Join the community at https://courier.getcruisecontrol.com/community?utm_source=cwctl
+Join the community at https://getcruisecontrol.com/community?utm_source=cwctl
 ***************************************************************************
 
 EOF
@@ -650,7 +650,7 @@ Exit status:
 Returns 0 if successful; non-zero otherwise.
 
 Report bugs at https://github.com/chatwoot/chatwoot/issues
-Get help, https://courier.getcruisecontrol.com/community?utm_source=cwctl
+Get help, https://getcruisecontrol.com/community?utm_source=cwctl
 
 EOF
 }

--- a/deployment/setup_20.04.sh
+++ b/deployment/setup_20.04.sh
@@ -451,7 +451,7 @@ function ssl_success_message() {
 Woot! Woot!! Chatwoot server installation is complete.
 The server will be accessible at https://$domain_name
 
-Join the community at https://chatwoot.com/community?utm_source=cwctl
+Join the community at https://courier.getcruisecontrol.com/community?utm_source=cwctl
 ***************************************************************************
 
 EOF
@@ -563,7 +563,7 @@ The server will be accessible at http://$public_ip:3000
 To configure a domain and SSL certificate, follow the guide at
 https://www.chatwoot.com/docs/deployment/deploy-chatwoot-in-linux-vm?utm_source=cwctl
 
-Join the community at https://chatwoot.com/community?utm_source=cwctl
+Join the community at https://courier.getcruisecontrol.com/community?utm_source=cwctl
 ***************************************************************************
 
 EOF
@@ -650,7 +650,7 @@ Exit status:
 Returns 0 if successful; non-zero otherwise.
 
 Report bugs at https://github.com/chatwoot/chatwoot/issues
-Get help, https://chatwoot.com/community?utm_source=cwctl
+Get help, https://courier.getcruisecontrol.com/community?utm_source=cwctl
 
 EOF
 }

--- a/enterprise/config/premium_installation_config.yml
+++ b/enterprise/config/premium_installation_config.yml
@@ -8,15 +8,15 @@
 - name: LOGO_DARK
   value: '/brand-assets/logo_dark.svg'
 - name: BRAND_URL
-  value: 'https://www.chatwoot.com'
+  value: 'https://courier.getcruisecontrol.com'
 - name: WIDGET_BRAND_URL
-  value: 'https://www.chatwoot.com'
+  value: 'https://courier.getcruisecontrol.com'
 - name: BRAND_NAME
   value: 'Chatwoot'
 - name: TERMS_URL
-  value: 'https://www.chatwoot.com/terms-of-service'
+  value: 'https://courier.getcruisecontrol.com/terms-of-service'
 - name: PRIVACY_URL
-  value: 'https://www.chatwoot.com/privacy-policy'
+  value: 'https://courier.getcruisecontrol.com/privacy-policy'
 - name: DISPLAY_MANIFEST
   value: true
 # ------- End of Branding Related Config ------- #

--- a/enterprise/config/premium_installation_config.yml
+++ b/enterprise/config/premium_installation_config.yml
@@ -8,15 +8,15 @@
 - name: LOGO_DARK
   value: '/brand-assets/logo_dark.svg'
 - name: BRAND_URL
-  value: 'https://courier.getcruisecontrol.com'
+  value: 'https://getcruisecontrol.com'
 - name: WIDGET_BRAND_URL
-  value: 'https://courier.getcruisecontrol.com'
+  value: 'https://getcruisecontrol.com'
 - name: BRAND_NAME
   value: 'Chatwoot'
 - name: TERMS_URL
-  value: 'https://courier.getcruisecontrol.com/terms-of-service'
+  value: 'https://getcruisecontrol.com/terms-of-service'
 - name: PRIVACY_URL
-  value: 'https://courier.getcruisecontrol.com/privacy-policy'
+  value: 'https://getcruisecontrol.com/privacy-policy'
 - name: DISPLAY_MANIFEST
   value: true
 # ------- End of Branding Related Config ------- #

--- a/enterprise/config/premium_installation_config.yml
+++ b/enterprise/config/premium_installation_config.yml
@@ -1,6 +1,6 @@
 # ------- Branding Related Config ------- #
 - name: INSTALLATION_NAME
-  value: 'Chatwoot'
+  value: 'Cruise Control'
 - name: LOGO_THUMBNAIL
   value: '/brand-assets/logo_thumbnail.svg'
 - name: LOGO
@@ -12,7 +12,7 @@
 - name: WIDGET_BRAND_URL
   value: 'https://getcruisecontrol.com'
 - name: BRAND_NAME
-  value: 'Chatwoot'
+  value: 'Cruise Control'
 - name: TERMS_URL
   value: 'https://getcruisecontrol.com/terms-of-service'
 - name: PRIVACY_URL

--- a/spec/factories/dashboard_app.rb
+++ b/spec/factories/dashboard_app.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :dashboard_app do
     sequence(:title) { |n| "Dashboard App #{n}" }
-    content { [{ type: 'frame', url: 'https://chatwoot.com' }] }
+    content { [{ type: 'frame', url: 'https://courier.getcruisecontrol.com' }] }
     user
     account
   end

--- a/spec/factories/dashboard_app.rb
+++ b/spec/factories/dashboard_app.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :dashboard_app do
     sequence(:title) { |n| "Dashboard App #{n}" }
-    content { [{ type: 'frame', url: 'https://courier.getcruisecontrol.com' }] }
+    content { [{ type: 'frame', url: 'https://getcruisecontrol.com' }] }
     user
     account
   end

--- a/spec/lib/integrations/slack/incoming_message_builder_spec.rb
+++ b/spec/lib/integrations/slack/incoming_message_builder_spec.rb
@@ -72,7 +72,7 @@ describe Integrations::Slack::IncomingMessageBuilder do
         allow(builder).to receive(:sender).and_return(nil)
         2.times.each { builder.perform }
         expect(conversation.messages.count).to eql(messages_count + 1)
-        expect(conversation.messages.last.content).to eql('this is test https://chatwoot.com Hey @Sojan Test again')
+        expect(conversation.messages.last.content).to eql('this is test https://courier.getcruisecontrol.com Hey @Sojan Test again')
       end
 
       it 'creates message' do
@@ -82,7 +82,7 @@ describe Integrations::Slack::IncomingMessageBuilder do
         allow(builder).to receive(:sender).and_return(nil)
         builder.perform
         expect(conversation.messages.count).to eql(messages_count + 1)
-        expect(conversation.messages.last.content).to eql('this is test https://chatwoot.com Hey @Sojan Test again')
+        expect(conversation.messages.last.content).to eql('this is test https://courier.getcruisecontrol.com Hey @Sojan Test again')
       end
 
       it 'creates a private note' do
@@ -142,7 +142,7 @@ describe Integrations::Slack::IncomingMessageBuilder do
         allow(builder).to receive(:sender).and_return(nil)
         builder.perform
         expect(conversation.messages.count).to eql(messages_count + 1)
-        expect(conversation.messages.last.content).to eql('this is test https://chatwoot.com Hey @Sojan Test again')
+        expect(conversation.messages.last.content).to eql('this is test https://courier.getcruisecontrol.com Hey @Sojan Test again')
         expect(conversation.messages.last.attachments).to be_any
       end
 

--- a/spec/lib/integrations/slack/incoming_message_builder_spec.rb
+++ b/spec/lib/integrations/slack/incoming_message_builder_spec.rb
@@ -72,7 +72,7 @@ describe Integrations::Slack::IncomingMessageBuilder do
         allow(builder).to receive(:sender).and_return(nil)
         2.times.each { builder.perform }
         expect(conversation.messages.count).to eql(messages_count + 1)
-        expect(conversation.messages.last.content).to eql('this is test https://courier.getcruisecontrol.com Hey @Sojan Test again')
+        expect(conversation.messages.last.content).to eql('this is test https://getcruisecontrol.com Hey @Sojan Test again')
       end
 
       it 'creates message' do
@@ -82,7 +82,7 @@ describe Integrations::Slack::IncomingMessageBuilder do
         allow(builder).to receive(:sender).and_return(nil)
         builder.perform
         expect(conversation.messages.count).to eql(messages_count + 1)
-        expect(conversation.messages.last.content).to eql('this is test https://courier.getcruisecontrol.com Hey @Sojan Test again')
+        expect(conversation.messages.last.content).to eql('this is test https://getcruisecontrol.com Hey @Sojan Test again')
       end
 
       it 'creates a private note' do
@@ -142,7 +142,7 @@ describe Integrations::Slack::IncomingMessageBuilder do
         allow(builder).to receive(:sender).and_return(nil)
         builder.perform
         expect(conversation.messages.count).to eql(messages_count + 1)
-        expect(conversation.messages.last.content).to eql('this is test https://courier.getcruisecontrol.com Hey @Sojan Test again')
+        expect(conversation.messages.last.content).to eql('this is test https://getcruisecontrol.com Hey @Sojan Test again')
         expect(conversation.messages.last.attachments).to be_any
       end
 

--- a/spec/support/slack_stubs.rb
+++ b/spec/support/slack_stubs.rb
@@ -51,7 +51,7 @@ module SlackStubs
 
       client_msg_id: 'ffc6e64e-6f0c-4a3d-b594-faa6b44e48ab',
       type: 'message',
-      text: 'this is test <https://chatwoot.com> Hey <@U019KT237LP|Sojan> Test again',
+      text: 'this is test <https://courier.getcruisecontrol.com> Hey <@U019KT237LP|Sojan> Test again',
       user: 'ULYPAKE5S',
       ts: '1588623033.006000',
       team: 'TLST3048H',
@@ -99,7 +99,7 @@ module SlackStubs
     {
       client_msg_id: 'ffc6e64e-6f0c-4a3d-b594-faa6b44e48ab',
       type: 'message',
-      text: 'this is test <https://chatwoot.com> Hey <@U019KT237LP|Sojan> Test again',
+      text: 'this is test <https://courier.getcruisecontrol.com> Hey <@U019KT237LP|Sojan> Test again',
       user: 'ULYPAKE5S',
       ts: '1588623033.006000',
       files: file_stub,

--- a/spec/support/slack_stubs.rb
+++ b/spec/support/slack_stubs.rb
@@ -51,7 +51,7 @@ module SlackStubs
 
       client_msg_id: 'ffc6e64e-6f0c-4a3d-b594-faa6b44e48ab',
       type: 'message',
-      text: 'this is test <https://courier.getcruisecontrol.com> Hey <@U019KT237LP|Sojan> Test again',
+      text: 'this is test <https://getcruisecontrol.com> Hey <@U019KT237LP|Sojan> Test again',
       user: 'ULYPAKE5S',
       ts: '1588623033.006000',
       team: 'TLST3048H',
@@ -99,7 +99,7 @@ module SlackStubs
     {
       client_msg_id: 'ffc6e64e-6f0c-4a3d-b594-faa6b44e48ab',
       type: 'message',
-      text: 'this is test <https://courier.getcruisecontrol.com> Hey <@U019KT237LP|Sojan> Test again',
+      text: 'this is test <https://getcruisecontrol.com> Hey <@U019KT237LP|Sojan> Test again',
       user: 'ULYPAKE5S',
       ts: '1588623033.006000',
       files: file_stub,


### PR DESCRIPTION
## Description

Replaced all instances of "https://chatwoot.com" -> "https://courier.getcruisecontrol.com/)" into settings, configurations and specs.