### PR TITLE
feat: add an retry ability for stark api to get response incase of failed attempt

### DIFF
--- a/app/controllers/platform/api/v1/accounts_controller.rb
+++ b/app/controllers/platform/api/v1/accounts_controller.rb
@@ -38,6 +38,6 @@ class Platform::Api::V1::AccountsController < PlatformController
   end
 
   def permitted_params
-    params.permit(:name, :locale, :domain, :support_email, :status, features: {}, limits: {}, custom_attributes: {})
+    params.permit(:name, :locale, :domain, :support_email, :status, :dealership_id, features: {}, limits: {}, custom_attributes: {})
   end
 end

--- a/app/models/concerns/stark_retryable.rb
+++ b/app/models/concerns/stark_retryable.rb
@@ -1,0 +1,39 @@
+module StarkRetryable
+  extend ActiveSupport::Concern
+
+  MAX_RETRIES = 1
+  RETRY_DELAY = 3
+
+  def with_stark_retry(conversation = nil)
+    retries = 0
+    begin
+      yield
+    rescue StandardError => e
+      retries += 1
+      if retries <= MAX_RETRIES
+        Rails.logger.warn("Stark server error encountered. Attempt #{retries} of #{MAX_RETRIES}. Retrying in #{RETRY_DELAY} seconds...")
+        sleep(RETRY_DELAY)
+        retry
+      else
+        Rails.logger.error("Stark server error persisted after #{MAX_RETRIES} retries. Handing off to human agent.")
+        handle_human_handoff(conversation, e) if conversation
+        nil
+      end
+    end
+  end
+
+  private
+
+  def handle_human_handoff(conversation, _error)
+    return unless conversation
+
+    conversation.open!
+    conversation.messages.create!(
+      content: '⚠️ Auto Reply Service Disabled: The auto reply agent has been disabled due to some issues. The conversation is now swicth to human mode and requires your attention. Please contact support if the issue persists or set the conversation back to pending mode to enable auto reply mode.',
+      message_type: 'outgoing',
+      account_id: conversation.account_id,
+      inbox_id: conversation.inbox_id,
+      private: true
+    )
+  end
+end

--- a/config/features.yml
+++ b/config/features.yml
@@ -136,10 +136,10 @@
 - name: linear_integration
   display_name: Linear Integration
   enabled: false
-# - name: captain_integration
-#   display_name: Captain
-#   enabled: false
-#   premium: true
+- name: captain_integration
+  display_name: Captain
+  enabled: false
+  premium: true
 - name: custom_roles
   display_name: Custom Roles
   enabled: false

--- a/lib/integrations/stark/processor_service.rb
+++ b/lib/integrations/stark/processor_service.rb
@@ -26,19 +26,16 @@ class Integrations::Stark::ProcessorService < Integrations::BotProcessorService
 
   def process_stark_response
     response = get_stark_response(current_conversation, event_data[:message].content)
-    return mark_conversation_open if invalid_response?(response)
+    return if response.nil? # Response is nil if there was an error (already handled by StarkRetryable)
 
     handle_response(response)
   end
 
   def handle_missing_dealership_id
-    return false unless current_conversation.account&.dealership_id.blank?
+    return false if current_conversation.account&.dealership_id.present?
+
     mark_conversation_open
     true
-  end
-
-  def invalid_response?(response)
-    response.blank? || !response_valid?(response)
   end
 
   def current_conversation

--- a/spec/controllers/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/api/v1/accounts_controller_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe 'Accounts API', type: :request do
         with_modified_env ENABLE_ACCOUNT_SIGNUP: 'true' do
           allow(account_builder).to receive(:perform).and_return([user, account])
 
-          params = { account_name: 'test', email: email, user: nil, locale: nil, user_full_name: user_full_name, password: 'Password1!' }
+          params = { account_name: 'test', email: email, user: nil, locale: nil, user_full_name: user_full_name, password: 'Password1!',
+                     dealership_id: '123' }
 
           post api_v1_accounts_url,
                params: params,
@@ -39,7 +40,7 @@ RSpec.describe 'Accounts API', type: :request do
           allow(captcha).to receive(:valid?).and_return(true)
 
           params = { account_name: 'test', email: email, user: nil, locale: nil, user_full_name: user_full_name, password: 'Password1!',
-                     h_captcha_client_response: '123' }
+                     h_captcha_client_response: '123', dealership_id: '123' }
 
           post api_v1_accounts_url,
                params: params,
@@ -83,7 +84,8 @@ RSpec.describe 'Accounts API', type: :request do
 
     context 'when ENABLE_ACCOUNT_SIGNUP env variable is set to api_only' do
       it 'does not respond 404 on requests' do
-        params = { account_name: 'test', email: email, user_full_name: user_full_name, password: 'Password1!' }
+        params = { account_name: 'test', email: email, user_full_name: user_full_name, password: 'Password1!', dealership_id: '123',
+                   h_captcha_client_response: '123' }
         with_modified_env ENABLE_ACCOUNT_SIGNUP: 'api_only' do
           post api_v1_accounts_url,
                params: params,

--- a/spec/controllers/platform/api/v1/accounts_controller_spec.rb
+++ b/spec/controllers/platform/api/v1/accounts_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Platform Accounts API', type: :request do
       let(:platform_app) { create(:platform_app) }
 
       it 'creates an account when and its permissible relationship' do
-        post '/platform/api/v1/accounts', params: { name: 'Test Account' },
+        post '/platform/api/v1/accounts', params: { name: 'Test Account', dealership_id: '123' },
                                           headers: { api_access_token: platform_app.access_token.token }, as: :json
 
         expect(response).to have_http_status(:success)
@@ -34,7 +34,7 @@ RSpec.describe 'Platform Accounts API', type: :request do
       it 'creates an account with locale' do
         InstallationConfig.where(name: 'ACCOUNT_LEVEL_FEATURE_DEFAULTS').first_or_create!(value: [{ 'name' => 'agent_management',
                                                                                                     'enabled' => true }])
-        post '/platform/api/v1/accounts', params: { name: 'Test Account', locale: 'es' },
+        post '/platform/api/v1/accounts', params: { name: 'Test Account', locale: 'es', dealership_id: '123' },
                                           headers: { api_access_token: platform_app.access_token.token }, as: :json
 
         expect(response).to have_http_status(:success)
@@ -53,7 +53,7 @@ RSpec.describe 'Platform Accounts API', type: :request do
                                                                                                   { 'name' => 'help_center',
                                                                                                     'enabled' => false }])
 
-        post '/platform/api/v1/accounts', params: { name: 'Test Account', features: {
+        post '/platform/api/v1/accounts', params: { name: 'Test Account', dealership_id: '123', features: {
           ip_lookup: true,
           help_center: true,
           disable_branding: false
@@ -67,7 +67,7 @@ RSpec.describe 'Platform Accounts API', type: :request do
       end
 
       it 'creates an account with limits settings' do
-        post '/platform/api/v1/accounts', params: { name: 'Test Account', limits: { agents: 5, inboxes: 10 } },
+        post '/platform/api/v1/accounts', params: { name: 'Test Account', dealership_id: '123', limits: { agents: 5, inboxes: 10 } },
                                           headers: { api_access_token: platform_app.access_token.token }, as: :json
 
         expect(response).to have_http_status(:success)

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     status { 'active' }
     domain { 'test.com' }
     support_email { 'support@test.com' }
+    dealership_id { '123' }
   end
 end


### PR DESCRIPTION
## Release Notes:

- Add an retry ability for stark api to get response incase of failed attempt. The operation will be performed after an 3-second delay.
- Incase of failed attempt, it will display a private message in chat incase, visible to only agents and admins.