### PR TITLE
fix:  skipped activity messages from messages list of conversation

### DIFF
--- a/app/controllers/api/v1/external/conversations_controller.rb
+++ b/app/controllers/api/v1/external/conversations_controller.rb
@@ -30,6 +30,7 @@ class Api::V1::External::ConversationsController < Api::BaseController
 
   def fetch_paginated_messages(conversation)
     conversation.messages
+                .not_activity
                 .select(:conversation_id, :message_type, :content, :created_at)
                 .reorder(sort_params)
                 .page(params[:page])


### PR DESCRIPTION
## Description
Prevent the activity messages (status changes, assignments, and other system activities) from conversation messages list.