### PR TITLE
fix: disabled handoff to human along with avoid attachment responses to be sent to stark

### DIFF
--- a/app/controllers/concerns/stark/api_handler.rb
+++ b/app/controllers/concerns/stark/api_handler.rb
@@ -66,7 +66,7 @@ module Stark
       data = response['body']['data']
       {
         'content' => data['answer'],
-        'action' => data['human_redirect'] ? 'handoff' : nil
+        'action' => data['human_redirect'] ? nil : nil #'handoff if human_redirect is true'
       }
     end
 

--- a/lib/integrations/stark/processor_service.rb
+++ b/lib/integrations/stark/processor_service.rb
@@ -19,6 +19,7 @@ class Integrations::Stark::ProcessorService < Integrations::BotProcessorService
   def process_conversation
     return unless should_run_processor?(event_data[:message])
     return if handle_missing_dealership_id
+    return if event_data[:message].content.blank?
 
     process_stark_response
   end


### PR DESCRIPTION
## Description
- The handoff to human has been totally disabled and could only enable manually. 
- Prevent sending messages containing empty content in case of attachments to Stark. 