### PR TITLE
fix: Removed installation identifier and updated related files

### DIFF
--- a/app/views/super_admin/application/_javascript.html.erb
+++ b/app/views/super_admin/application/_javascript.html.erb
@@ -41,7 +41,7 @@ window.chatwootSettings = {
 })(document,"script");
 
 window.addEventListener('chatwoot:ready', function() {
-  window.$chatwoot.setUser('<%= ChatwootHub.installation_identifier %>', {
+  window.$chatwoot.setUser('<%= SuperAdmin.first.email %>', {
     identifier_hash: '<%= ChatwootHub.support_config[:support_identifier_hash] %>',
     email: '<%= SuperAdmin.first.email %>',
     name: '<%= SuperAdmin.first.name %>'

--- a/app/views/super_admin/settings/show.html.erb
+++ b/app/views/super_admin/settings/show.html.erb
@@ -31,10 +31,6 @@
         </a>
       </div>
       <p class="text-n-slate-11 mt-1"><%= SuperAdmin::FeaturesHelper.plan_details.html_safe %></p>
-      <div class="flex items-center mt-6">
-        <h4 class="text-sm font-medium leading-5 h-5 text-n-slate-12 mr-4">Installation Identifier</h4>
-        <span class="text-sm leading-5 h-5 text-n-slate-11"><%= ChatwootHub.installation_identifier %></span>
-      </div>
     </div>
     <div class="flex p-4 outline outline-1 outline-n-container rounded-lg mt-8 items-start md:items-center shadow-sm flex-col md:flex-row">
       <div class="flex flex-col flex-grow gap-1">

--- a/db/migrate/20250527051205_remove_installation_idenitifier_config.rb
+++ b/db/migrate/20250527051205_remove_installation_idenitifier_config.rb
@@ -1,0 +1,6 @@
+class RemoveInstallationIdenitifierConfig < ActiveRecord::Migration[7.0]
+  def up
+    config = InstallationConfig.find_by(name: 'INSTALLATION_IDENTIFIER')
+    config&.destroy
+  end
+end

--- a/deployment/setup_20.04.sh
+++ b/deployment/setup_20.04.sh
@@ -943,11 +943,8 @@ function report_event() {
 
   CHATWOOT_HUB_URL="https://hub.2.chatwoot.com/events"
 
-  # get installation identifier
-  local installation_identifier=$(get_installation_identifier)
-
   # Prepare the data for the request
-  local data="{\"installation_identifier\":\"$installation_identifier\",\"event_name\":\"$event_name\",\"event_data\":{\"action\":\"$event_data\"}}"
+  local data="{\"event_name\":\"$event_name\",\"event_data\":{\"action\":\"$event_data\"}}"
 
   # Make the curl request to report the event
   curl -X POST -H "Content-Type: application/json" -d "$data" "$CHATWOOT_HUB_URL" -s -o /dev/null
@@ -963,17 +960,17 @@ function report_event() {
 # Outputs:
 #   installation_identifier
 ##############################################################################
-function get_installation_identifier() {
+# function get_installation_identifier() {
 
-  local installation_identifier
+#   local installation_identifier
 
-  installation_identifier=$(sudo -i -u chatwoot << "EOF"
-  cd chatwoot
-  RAILS_ENV=production bundle exec rake instance_id:get_installation_identifier
-EOF
-)
-  echo "$installation_identifier"
-}
+#   installation_identifier=$(sudo -i -u chatwoot << "EOF"
+#   cd chatwoot
+#   RAILS_ENV=production bundle exec rake instance_id:get_installation_identifier
+# EOF
+# )
+#   echo "$installation_identifier"
+# }
 
 ##############################################################################
 # Print cwctl version (-v/--version)

--- a/lib/chatwoot_hub.rb
+++ b/lib/chatwoot_hub.rb
@@ -8,14 +8,8 @@ class ChatwootHub
   BILLING_URL = "#{BASE_URL}/billing".freeze
   CAPTAIN_ACCOUNTS_URL = "#{BASE_URL}/instance_captain_accounts".freeze
 
-  def self.installation_identifier
-    identifier = InstallationConfig.find_by(name: 'INSTALLATION_IDENTIFIER')&.value
-    identifier ||= InstallationConfig.create!(name: 'INSTALLATION_IDENTIFIER', value: SecureRandom.uuid).value
-    identifier
-  end
-
   def self.billing_url
-    "#{BILLING_URL}?installation_identifier=#{installation_identifier}"
+    BILLING_URL
   end
 
   def self.pricing_plan
@@ -36,7 +30,6 @@ class ChatwootHub
 
   def self.instance_config
     {
-      installation_identifier: installation_identifier,
       installation_version: Chatwoot.config[:version],
       installation_host: URI.parse(ENV.fetch('FRONTEND_URL', '')).host,
       installation_env: ENV.fetch('INSTALLATION_ENV', ''),
@@ -94,7 +87,6 @@ class ChatwootHub
 
   def self.get_captain_settings(account)
     info = {
-      installation_identifier: installation_identifier,
       chatwoot_account_id: account.id,
       account_name: account.name
     }

--- a/lib/tasks/instance_id.rake
+++ b/lib/tasks/instance_id.rake
@@ -1,8 +1,0 @@
-namespace :instance_id do
-  desc 'Get the installation identifier'
-  task :get_installation_identifier => :environment do
-    identifier = InstallationConfig.find_by(name: 'INSTALLATION_IDENTIFIER')&.value
-    identifier ||= InstallationConfig.create!(name: 'INSTALLATION_IDENTIFIER', value: SecureRandom.uuid).value
-    puts identifier
-  end
-end

--- a/spec/lib/chatwoot_hub_spec.rb
+++ b/spec/lib/chatwoot_hub_spec.rb
@@ -1,12 +1,7 @@
 require 'rails_helper'
 
 describe ChatwootHub do
-  it 'generates installation identifier' do
-    installation_identifier = described_class.installation_identifier
-    expect(installation_identifier).not_to be_nil
-    expect(described_class.installation_identifier).to eq installation_identifier
-  end
-
+  
   context 'when fetching sync_with_hub' do
     it 'get latest version from chatwoot hub' do
       version = '1.1.1'
@@ -74,7 +69,7 @@ describe ChatwootHub do
     it 'returns the captain settings' do
       account = create(:account)
       stub_request(:post, ChatwootHub::CAPTAIN_ACCOUNTS_URL).with(
-        body: { installation_identifier: described_class.installation_identifier, chatwoot_account_id: account.id, account_name: account.name }
+        body: { chatwoot_account_id: account.id, account_name: account.name }
       ).to_return(
         body: { account_email: 'test@test.com', account_id: '123', access_token: '123', assistant_id: '123' }.to_json
       )


### PR DESCRIPTION
This PR implements the removal of the Chatwoot installation identifier from the system. The changes ensure compliance with privacy policies and system requirements while maintaining the stability of the Chatwoot application. The following modifications were made:

Changes:

- lib/chatwoot_hub.rb: Updated to remove references to the installation identifier.
- spec/lib/chatwoot_hub_spec.rb: Adjusted test cases to reflect changes in the installation identifier handling.
- deployment/setup_20.04.sh: Updated script to account for removal of the identifier during setup.
- app/views/super_admin/application/_javascript.html.erb: Removed any UI elements or JavaScript code relying on the installation identifier.
- lib/tasks/instance_id.rake: Removed task to ensure the identifier is not generated or used.
- app/views/super_admin/settings/show.html.erb: Modified settings page to remove any references to the installation identifier.
- db/migrate/20250527051205_remove_installation_idenitifier_config.rb: Added migration to remove already created Installation Identifier from DB.

Testing:

- All relevant tests have been updated to reflect the changes.
- Manual verification has been done to ensure system stability and that no references to the installation ID remain in the application.