### PR TITLE
feat: stark automatically assign to the newly created inbox of any account

### DIFF
--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -38,7 +38,7 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
         )
       )
       @inbox.save!
-      assign_bot_to_inbox(@inbox)
+      assign_stark_as_default_bot(@inbox)
     end
   end
 
@@ -160,10 +160,8 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
 
   # Assigns a bot to the inbox based on availability and type
   # @param inbox [Inbox] The inbox to assign the bot to
-  def assign_bot_to_inbox(inbox)
+  def assign_stark_as_default_bot(inbox)
     return if inbox.nil?
-
-    inbox.agent_bot_inbox&.destroy! if inbox.agent_bot_inbox.present?
 
     begin
       agent_bot = AgentBot.find_by(bot_type: 'stark')

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -38,6 +38,7 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
         )
       )
       @inbox.save!
+      assign_bot_to_inbox(@inbox)
     end
   end
 
@@ -154,6 +155,26 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
       channel_type.constantize::EDITABLE_ATTRS.presence
     else
       []
+    end
+  end
+
+  # Assigns a bot to the inbox based on availability and type
+  # @param inbox [Inbox] The inbox to assign the bot to
+  def assign_bot_to_inbox(inbox)
+    return if inbox.nil?
+
+    inbox.agent_bot_inbox&.destroy! if inbox.agent_bot_inbox.present?
+
+    begin
+      agent_bot = AgentBot.find_by(bot_type: 'stark')
+      agent_bot ||= inbox.account.agent_bots.first if inbox.account.agent_bots.exists?
+
+      if agent_bot
+        agent_bot_inbox = AgentBotInbox.new(inbox: inbox, agent_bot: agent_bot)
+        agent_bot_inbox.save!
+      end
+    rescue StandardError => e
+      Rails.logger.error("Failed to assign bot to inbox: #{e.message}")
     end
   end
 end

--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -161,16 +161,15 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
   # Assigns a bot to the inbox based on availability and type
   # @param inbox [Inbox] The inbox to assign the bot to
   def assign_stark_as_default_bot(inbox)
-    return if inbox.nil?
+    return if inbox.blank?
 
     begin
       agent_bot = AgentBot.find_by(bot_type: 'stark')
       agent_bot ||= inbox.account.agent_bots.first if inbox.account.agent_bots.exists?
 
-      if agent_bot
-        agent_bot_inbox = AgentBotInbox.new(inbox: inbox, agent_bot: agent_bot)
-        agent_bot_inbox.save!
-      end
+      return unless agent_bot
+
+      AgentBotInbox.create!(inbox: inbox, agent_bot: agent_bot)
     rescue StandardError => e
       Rails.logger.error("Failed to assign bot to inbox: #{e.message}")
     end


### PR DESCRIPTION
## Description
This PR sets Stark as the default bot in inbox -> bot configuration. With these changes, any newly created inbox will automatically have Stark assigned to it as bot agent, eliminating the need to manually set the bot in the settings each time. The following modifications were made.