### PR TITLE
Fix: Refactor bot assignment to use model callback

### DIFF
--- a/app/controllers/api/v1/accounts/inboxes_controller.rb
+++ b/app/controllers/api/v1/accounts/inboxes_controller.rb
@@ -38,7 +38,6 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
         )
       )
       @inbox.save!
-      assign_stark_as_default_bot(@inbox)
     end
   end
 
@@ -155,23 +154,6 @@ class Api::V1::Accounts::InboxesController < Api::V1::Accounts::BaseController
       channel_type.constantize::EDITABLE_ATTRS.presence
     else
       []
-    end
-  end
-
-  # Assigns a bot to the inbox based on availability and type
-  # @param inbox [Inbox] The inbox to assign the bot to
-  def assign_stark_as_default_bot(inbox)
-    return if inbox.blank?
-
-    begin
-      agent_bot = AgentBot.find_by(bot_type: 'stark')
-      agent_bot ||= inbox.account.agent_bots.first if inbox.account.agent_bots.exists?
-
-      return unless agent_bot
-
-      AgentBotInbox.create!(inbox: inbox, agent_bot: agent_bot)
-    rescue StandardError => e
-      Rails.logger.error("Failed to assign bot to inbox: #{e.message}")
     end
   end
 end


### PR DESCRIPTION
- Previously, the logic to add "Stark" as the default bot was implemented in specific controllers (inbox_controller.rb).
- However, Facebook and Instagram inboxes use different controllers (callback_controller.rb), which caused inconsistency.
- Moved the bot assignment logic to the Inbox model using an after_create callback.
- This ensures that a default bot is automatically assigned whenever any inbox is created, regardless of the controller used.