### PR TITLE
feat: adding field is_follow_up_message to message payload

### DIFF
--- a/app/controllers/concerns/stark/api_handler.rb
+++ b/app/controllers/concerns/stark/api_handler.rb
@@ -67,7 +67,8 @@ module Stark
           conversation_id: message.conversation_id,
           message_type: message.message_type,
           content: message.content,
-          created_at: message.created_at
+          created_at: message.created_at,
+          is_follow_up_message: message.content_attributes['follow_up'] || false,
         }
       end
     end

--- a/app/services/stark/follow_up_service.rb
+++ b/app/services/stark/follow_up_service.rb
@@ -122,6 +122,7 @@ module Stark
           message_type: message.message_type,
           content: message.content,
           created_at: message.created_at
+          is_follow_up_message: message.content_attributes['follow_up'] || false,
         }
       end
     end


### PR DESCRIPTION
Adding the field is_follow_up_message to every message payload sent to Stark, so that Stark can easily skip responses when the user chooses to end the conversation.