### PR TITLE
Feature/send message api

### DIFF
--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -77,8 +77,9 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
   private
 
   def recipients(account)
-    account.account_users.includes(:user).map(&:user).compact
-  end
+  User.joins(:account_users)
+      .where(account_users: { account_id: account.id, role: 'agent' })
+end
 
   def message
     @message ||= @conversation.messages.find(permitted_params[:id])

--- a/app/controllers/api/v1/accounts/conversations/messages_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations/messages_controller.rb
@@ -45,7 +45,40 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
     render json: { content: translated_content }
   end
 
+  def send_email_notification
+    conversation = Conversation.find_by(display_id: params[:conversation_id])
+    account = conversation.account
+    template = EmailTemplate.find_by!(slug: params[:template_slug], account_id: account.id)
+    return render json: { error: 'Template not found' }, status: :not_found if template.nil?
+    
+    recipients = recipients(account).compact
+    
+    recipients.each do |agent|
+      next if agent.nil?
+  
+      AgentNotifications::CustomMailer.notification_email(
+        conversation,
+        agent,
+        template
+      ).deliver_later
+    end
+    
+    render json: { 
+      status: 'success', 
+      message: 'Email notifications sent successfully',
+      recipients: recipients.map(&:email)
+    }
+  rescue ActiveRecord::RecordNotFound => e
+    render json: { error: e.message }, status: :not_found
+  rescue StandardError => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
   private
+
+  def recipients(account)
+    account.account_users.includes(:user).map(&:user).compact
+  end
 
   def message
     @message ||= @conversation.messages.find(permitted_params[:id])
@@ -61,5 +94,9 @@ class Api::V1::Accounts::Conversations::MessagesController < Api::V1::Accounts::
 
   def already_translated_content_available?
     message.translations.present? && message.translations[permitted_params[:target_language]].present?
+  end
+
+  def email_notification_params
+    params.permit(:template_slug, :conversation_id)
   end
 end

--- a/app/controllers/super_admin/email_templates_controller.rb
+++ b/app/controllers/super_admin/email_templates_controller.rb
@@ -1,0 +1,47 @@
+class SuperAdmin::EmailTemplatesController < SuperAdmin::ApplicationController
+  def create
+    resource = resource_class.new(resource_params)
+    authorize_resource(resource)
+
+    if resource.save
+      redirect_to(
+        after_resource_created_path(resource),
+        notice: translate_with_resource("create.success")
+      )
+    else
+      render :new, locals: {
+        page: Administrate::Page::Form.new(dashboard, resource),
+      }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if requested_resource.update(resource_params)
+      redirect_to(
+        after_resource_updated_path(requested_resource),
+        notice: translate_with_resource("update.success")
+      )
+    else
+      render :edit, locals: {
+        page: Administrate::Page::Form.new(dashboard, requested_resource),
+      }, status: :unprocessable_entity
+    end
+  end
+
+  def check_slug_inbox
+    exists = EmailTemplate.exists?(slug: params[:slug], account_id: params[:account_id])
+    render json: { exists: exists }
+  end
+
+  private
+
+  def find_existing_template(resource)
+    EmailTemplate.find_by(slug: resource.slug, inbox: resource.inbox)
+  end
+
+  def resource_params
+    params.require(resource_class.model_name.param_key).
+      permit(dashboard.permitted_attributes(action_name)).
+      transform_values { |value| value == "" ? nil : value }
+  end
+end 

--- a/app/dashboards/email_template_dashboard.rb
+++ b/app/dashboards/email_template_dashboard.rb
@@ -1,0 +1,83 @@
+require "administrate/base_dashboard"
+
+class EmailTemplateDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    name: Field::String.with_options(searchable: true),
+    slug: Field::String.with_options(searchable: true),
+    account: Field::BelongsTo.with_options(
+      class_name: "Account",
+      searchable: true,
+      searchable_field: 'name'
+    ),
+    body: Field::Text.with_options(
+      searchable: false,
+      truncate: 50,
+      limit: 20_000,
+    ),
+    subject: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    name
+    slug
+    account
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    name
+    slug
+    subject
+    body
+    account
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    name
+    slug
+    subject
+    body
+    account
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {
+    recent: ->(resources) { resources.where('created_at > ?', 30.days.ago) }
+  }.freeze
+
+  # Overwrite this method to customize how email templates are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(email_template)
+    "#{email_template.name} (#{email_template.account&.name})"
+  end
+end

--- a/app/javascript/entrypoints/email_template_confirmation.js
+++ b/app/javascript/entrypoints/email_template_confirmation.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const form = document.getElementById('new_email_template');
+  if (!form) return;
+
+  const slugInput = form.querySelector('#email_template_slug');
+  const accountSelect = form.querySelector('#email_template_account_id');
+
+  async function checkSlugInbox() {
+    const slug = slugInput.value;
+    const accountId = accountSelect.value;
+    if (!slug) return false;
+
+    const response = await fetch(`/super_admin/email_templates/check_slug_inbox?slug=${encodeURIComponent(slug)}&account_id=${encodeURIComponent(accountId)}`,);
+    const data = await response.json();
+    return data.exists;
+  }
+
+  form.addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const exists = await checkSlugInbox();
+    if (exists) {
+      if (confirm('A template with this slug already exists for the selected account. The previous one will be replaced. Continue?')) {
+        form.submit();
+      }
+    } else {
+      form.submit();
+    }
+  });
+});

--- a/app/javascript/entrypoints/superadmin.js
+++ b/app/javascript/entrypoints/superadmin.js
@@ -1,1 +1,2 @@
 import '../dashboard/assets/scss/super_admin/index.scss';
+import './email_template_confirmation';

--- a/app/mailers/agent_notifications/custom_mailer.rb
+++ b/app/mailers/agent_notifications/custom_mailer.rb
@@ -1,0 +1,15 @@
+class AgentNotifications::CustomMailer < ApplicationMailer
+
+  def notification_email(conversation, recipient, template)
+    raise ArgumentError, "Parameter missing" if conversation.nil? || recipient.nil? || template.nil?
+
+    @conversation = conversation
+    @recipient = recipient
+    @template = template
+    
+    mail(
+      to: @recipient.email,
+      subject: @template.subject || 'Notification from Cruise Control',
+    )
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -80,7 +80,7 @@ class Account < ApplicationRecord
   has_many :webhooks, dependent: :destroy_async
   has_many :whatsapp_channels, dependent: :destroy_async, class_name: '::Channel::Whatsapp'
   has_many :working_hours, dependent: :destroy_async
-  has_many :email_template, dependent: :nullify
+  has_many :email_templates, dependent: :nullify
 
   has_one_attached :contacts_export
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -80,6 +80,7 @@ class Account < ApplicationRecord
   has_many :webhooks, dependent: :destroy_async
   has_many :whatsapp_channels, dependent: :destroy_async, class_name: '::Channel::Whatsapp'
   has_many :working_hours, dependent: :destroy_async
+  has_many :email_template, dependent: :nullify
 
   has_one_attached :contacts_export
 

--- a/app/models/email_template.rb
+++ b/app/models/email_template.rb
@@ -6,6 +6,8 @@
 #  body          :text             not null
 #  locale        :integer          default("en"), not null
 #  name          :string           not null
+#  slug          :string
+#  subject       :string
 #  template_type :integer          default("content")
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -20,9 +22,16 @@ class EmailTemplate < ApplicationRecord
   enum template_type: { layout: 0, content: 1 }
   belongs_to :account, optional: true
 
-  validates :name, uniqueness: { scope: :account }
+  before_create :delete_existing_slug_inbox_template
 
   def self.resolver(options = {})
     ::EmailTemplates::DbResolverService.using self, options
+  end
+
+  private
+
+  def delete_existing_slug_inbox_template
+    existing = EmailTemplate.find_by(slug: slug, account_id: account_id)
+    existing&.destroy
   end
 end

--- a/app/views/mailers/agent_notifications/custom_mailer/notification_email.html.erb
+++ b/app/views/mailers/agent_notifications/custom_mailer/notification_email.html.erb
@@ -1,0 +1,1 @@
+<%= @template.body.html_safe? ? raw(@template.body) : simple_format(@template.body) %>

--- a/app/views/super_admin/application/_navigation.html.erb
+++ b/app/views/super_admin/application/_navigation.html.erb
@@ -16,6 +16,7 @@ as defined by the routes in the `admin/` namespace
     users: 'icon-user-follow-line',
     platform_apps: 'icon-apps-2-line',
     agent_bots: 'icon-robot-line',
+    email_templates: 'icon-mail-send-fill',
     installation_configs: 'icon-settings-2-line'
   }
 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,9 @@ Rails.application.routes.draw do
                   post :translate
                   post :retry
                 end
+                  collection do
+                    post 'send-message', to: 'messages#send_email_notification'
+                  end  
               end
               resources :assignments, only: [:create]
               resources :labels, only: [:create, :index]
@@ -524,6 +527,11 @@ Rails.application.routes.draw do
       end
       resources :platform_apps, only: [:index, :new, :create, :show, :edit, :update, :destroy]
       resource :instance_status, only: [:show]
+      resources :email_templates do
+        collection do
+          get :check_slug_inbox
+        end
+      end    
 
       resource :settings, only: [:show] do
         get :refresh, on: :collection

--- a/db/migrate/20250630055853_add_slug_and_subject_in_email_template.rb
+++ b/db/migrate/20250630055853_add_slug_and_subject_in_email_template.rb
@@ -1,0 +1,6 @@
+class AddSlugAndSubjectInEmailTemplate < ActiveRecord::Migration[7.0]
+  def change
+    add_column :email_templates, :slug, :string
+    add_column :email_templates, :subject, :string
+  end
+end


### PR DESCRIPTION
Add Send Custom Email API and Super Admin Email Template Management

Send Custom Email API
- Created a new API endpoint to send custom emails.
- Accepts:
    - conversation_id
    - template_slug
-Finds the conversation and template.
-Sends an email to conversation participants based on the selected template.

Super Admin Email Template Management (Frontend)

- Added UI for super admins to:
- Create email templates
- Update email templates
- Delete email templates

Templates include:
- Subject
- Body content
- Slug (used for referencing in API calls)