### PR TITLE
feature: send stark failure notification on slack channel #CRUISE-331

### DIFF
--- a/app/controllers/concerns/stark/api_handler.rb
+++ b/app/controllers/concerns/stark/api_handler.rb
@@ -15,12 +15,29 @@ module Stark
         response = make_api_request(conversation, content)
 
         return nil if response.nil?
-        return handle_error_response(response) if error_response?(response)
-
-        parse_stark_response(response)
+    
+        status_code = response.dig('metadata', 'status_code').to_i
+    
+        case status_code
+        when 200
+          parse_stark_response(response)
+        when 400, 500
+          log_stark_error(status_code, response)
+          nil
+        else
+          log_and_notify_slack(
+            "[STARK API ERROR] Unexpected response: #{response.inspect}"
+          )
+          nil
+        end
       end
     rescue JSON::ParserError => e
       Rails.logger.error("Failed to parse Stark response: #{e.message}")
+      nil
+    rescue StandardError => e
+      log_and_notify_slack(
+        "[STARK API ERROR] Stark server error persisted: #{e.message}"
+      )
       nil
     end
 
@@ -112,6 +129,29 @@ module Stark
 
       Rails.logger.error("Stark API Error: #{error_details}")
       raise StandardError, error_message || 'Stark API Error'
+    end
+
+    def log_stark_error(status_code, response)
+      message = response.dig('body', 'message')
+      errors  = response.dig('body', 'errors')
+    
+      error_text = case status_code
+                   when 400
+                     "400 Bad Request: #{message}, Errors: #{errors}"
+                   when 500
+                     "500 Server Error: #{message}"
+                   else
+                     "Unknown Error (#{status_code}): #{response.inspect}"
+                   end
+    
+      log_and_notify_slack("[STARK API ERROR] #{error_text}")
+    end
+    
+    def log_and_notify_slack(message)
+      Rails.logger.error(message)
+      SlackNotifierService.call(
+        text: message
+      )
     end
   end
 end

--- a/app/jobs/conversation_handoff/send_handoff_notifications_job.rb
+++ b/app/jobs/conversation_handoff/send_handoff_notifications_job.rb
@@ -9,6 +9,9 @@ class ConversationHandoff::SendHandoffNotificationsJob < ApplicationJob
       AgentNotifications::ConversationHandoffMailer.notify_handoff(conversation).deliver_later
     rescue StandardError => e
       Rails.logger.error("Failed to send handoff notifications: #{e.message}")
+      SlackNotifierService.new(
+        text: "Handoff failed. Failed to send handoff notifications: #{e.message}"
+      )
     end
   end
 end

--- a/app/services/slack_notifier_service.rb
+++ b/app/services/slack_notifier_service.rb
@@ -1,0 +1,39 @@
+class SlackNotifierService
+    SLACK_API_URL = "https://slack.com/api/chat.postMessage".freeze
+  
+    def self.call(text:, channel: nil)
+        new(text: text, channel: channel).call
+    end
+
+    def initialize(text:, channel: nil)
+      @channel = channel.presence || ENV['SLACK_DEFAULT_CHANNEL']
+      @text = text
+      @slack_token = ENV['SLACK_BOT_TOKEN']
+    end
+  
+    def call
+      unless @slack_token.present?
+        Rails.logger.error("SLACK_BOT_TOKEN is missing in environment variables")
+        return
+      end
+  
+      response = HTTParty.post(
+        SLACK_API_URL,
+        headers: {
+          "Authorization" => "Bearer #{@slack_token}",
+          "Content-Type" => "application/json"
+        },
+        body: {
+          channel: @channel,
+          text: @text
+        }.to_json
+      )
+  
+      unless response&.parsed_response&.dig("ok")
+        Rails.logger.error("Slack API Error: #{response&.body}")
+      end
+    rescue => e
+      Rails.logger.error("Failed to send Slack message: #{e.message}")
+    end
+  end
+  

--- a/app/services/stark/follow_up_service.rb
+++ b/app/services/stark/follow_up_service.rb
@@ -24,17 +24,31 @@ module Stark
           response.dig('body', 'message')
         when 400
           # Invalid data: log and return nil
-          Rails.logger.error("Stark invalid data: #{response.dig('body', 'message')}, errors: #{response.dig('body', 'error')}")
+          message = response.dig('body', 'message')
+          errors = response.dig('body', 'errors')
+          log_and_notify_slack(
+            "[STARK FOLLOW-UP ERROR] 400 Bad Request: #{message}, Errors: #{errors}"
+          )
           nil
         when 500
           # Server error: log and return nil
-          Rails.logger.error("Stark server error: #{response.dig('body', 'message')}")
+          message = response.dig('body', 'message')
+          log_and_notify_slack(
+            "[STARK FOLLOW-UP ERROR] 500 Server Error: #{message}"
+          )
           nil
         else
           # Unexpected status: log and return nil
-          Rails.logger.error("Unexpected Stark response: #{response.inspect}")
+          log_and_notify_slack(
+            "[STARK FOLLOW-UP ERROR] Unexpected response: #{response.inspect}"
+          )
           nil
         end
+      rescue JSON::ParserError => e
+        log_and_notify_slack(
+          "[STARK FOLLOW-UP PARSE ERROR] Failed to parse Stark response: #{e.message}"
+        )
+        nil
       rescue StandardError => e
         retries += 1
         if retries <= MAX_RETRIES
@@ -42,7 +56,10 @@ module Stark
           sleep(RETRY_DELAY)
           retry
         end
-        Rails.logger.error("Stark server error persisted: #{e.message}")
+
+        log_and_notify_slack(
+          "[STARK FOLLOW-UP ERROR] Stark server error persisted: #{e.message}"
+        )
         nil
       end
     end
@@ -127,5 +144,11 @@ module Stark
       end
     end
 
+    def log_and_notify_slack(message)
+      Rails.logger.error(message)
+      SlackNotifierService.call(
+        text: message
+      )
+    end
   end
 end


### PR DESCRIPTION
This PR implements Slack notifications for critical errors in the Courier system to ensure timely visibility and faster troubleshooting.
Details: 
Slack Channel: #courier-notification

Notifications Added:
✅ Stark API Failures:
-Triggers a Slack message if:
* Stark fails to respond
* Any error occurs during Stark response handling

✅ Handoff Email Errors:
-Triggers a Slack message if:
*Any error occurs while sending handoff emails to agents

Environment Variables: 
NOTE: This feature requires two new environment variables:
SLACK_BOT_TOKEN — "The bot token of the Slack app being used"
SLACK_DEFAULT_CHANNEL — "The Slack channel ID where notifications should be sent"