### PR TITLE
fix: changing follow-up delay time

### DIFF
--- a/app/controllers/concerns/stark/message_handler.rb
+++ b/app/controllers/concerns/stark/message_handler.rb
@@ -8,18 +8,12 @@ module Stark
     end
 
     def create_bot_response_message(conversation, content)
-      sender = if conversation.inbox.channel_type == "Channel::WebWidget"
-                 conversation.inbox.channel&.avatar_name || agent_bot
-               else
-                 agent_bot
-               end
-    
       conversation.messages.create!(
         content: content,
         message_type: :outgoing,
         account_id: conversation.account_id,
         inbox_id: conversation.inbox_id,
-        sender: sender
+        sender: agent_bot
       )
     end    
 

--- a/app/jobs/conversations/follow_up_job.rb
+++ b/app/jobs/conversations/follow_up_job.rb
@@ -20,8 +20,10 @@ class Conversations::FollowUpJob < ApplicationJob
     case follow_up_number
     when 1
       create_follow_up_message(conversation, 1, stark_response)
-      # Schedule Follow-up 2 (if still no reply in 23h)
-      jid = Conversations::FollowUpJob.set(wait: 24.hours).perform_later(conversation.id, 2)
+      # Schedule Follow-up 2 (if still no reply in 22h)
+      config_value = InstallationConfig.find_by(name: 'FOLLOW_UP_SECOND_DELAY_HOURS')&.value
+      follow_up_2_delay = (config_value || 22).to_i.hours
+      jid = Conversations::FollowUpJob.set(wait: follow_up_2_delay).perform_later(conversation.id, 2)
       conversation.update!(follow_up_jid: jid.provider_job_id)
 
     when 2

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -413,7 +413,9 @@ class Message < ApplicationRecord
 
     return if conversation.stop_follow_up
 
-    jid = Conversations::FollowUpJob.set(wait: 24.hours).perform_later(conversation.id, 1)
+    config_value = InstallationConfig.find_by(name: 'FOLLOW_UP_FIRST_DELAY_HOURS')&.value
+    follow_up_1_delay = (config_value || 1).to_i.hours
+    jid = Conversations::FollowUpJob.set(wait: follow_up_1_delay).perform_later(conversation.id, 1)
     conversation.update!(follow_up_jid: jid.provider_job_id)
   end
 

--- a/config/installation_config.yml
+++ b/config/installation_config.yml
@@ -319,3 +319,16 @@
   value: 'v22.0'
   locked: true
 # ------- End of Instagram Channel Related Config ------- #
+
+# ------- Follow Up Job Config ------- #
+- name: FOLLOW_UP_FIRST_DELAY_HOURS
+  display_title: 'Follow Up First Delay Hours'
+  value: 1
+  description: 'The delay in hours before the first follow-up message is sent'
+  locked: false
+- name: FOLLOW_UP_SECOND_DELAY_HOURS
+  display_title: 'Follow Up Second Delay Hours'
+  value: 22
+  description: 'The delay in hours before the second follow-up message is sent'
+  locked: false
+# ------- End of Follow Up Job Config ------- #


### PR DESCRIPTION
**Summary**
  This PR updates the logic and configuration for the follow-up message delay times in the conversation flow. The changes allow the delay for the second follow-up message to be configurable via the installation configuration, improving flexibility for different deployment needs.
  
**Changes**

- Configurable Delay:
Added FOLLOW_UP_SECOND_DELAY_HOURS to config/installation_config.yml to control the delay (in hours) before the second follow-up message is sent.
The default value is set to 22 hours, but it can now be easily changed via the config file.

- Job Logic Update:
app/jobs/conversations/follow_up_job.rb now reads the delay for the second follow-up from the new config value instead of using a hardcoded value.
The job schedules the second follow-up based on this configurable delay.

- Supporting Changes:
Minor updates in app/models/message.rb and app/controllers/concerns/stark/message_handler.rb to support the new follow-up logic and ensure correct message creation and handling.