### PR TITLE
fix: update fb ig reply box

### DIFF
--- a/app/javascript/dashboard/components-next/message/MessageError.vue
+++ b/app/javascript/dashboard/components-next/message/MessageError.vue
@@ -6,7 +6,7 @@ import { useMessageContext } from './provider.js';
 import { hasOneDayPassed } from 'shared/helpers/timeHelper';
 import { ORIENTATION, MESSAGE_STATUS } from './constants';
 
-defineProps({
+const { error } = defineProps({
   error: { type: String, required: true },
 });
 
@@ -17,6 +17,9 @@ const { orientation, status, createdAt } = useMessageContext();
 const { t } = useI18n();
 
 const canRetry = computed(() => !hasOneDayPassed(createdAt.value));
+const displayError = computed(() => {
+return error.replace(/^\s*\(?#?\d+\)?\s*-?\s*/, '');
+});
 </script>
 
 <template>
@@ -38,7 +41,7 @@ const canRetry = computed(() => !hasOneDayPassed(createdAt.value));
           'ltr:right-0 rtl:left-0': orientation === ORIENTATION.RIGHT,
         }"
       >
-        {{ error }}
+        {{ displayError }}
       </div>
     </div>
     <button

--- a/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/ReplyBox.vue
@@ -203,11 +203,17 @@ export default {
       return this.isATwilioWhatsAppChannel && !this.isPrivate;
     },
 
+    isInstagramDM() {
+      return this.conversationType === 'instagram_direct_message' || this.isAnInstagramChannel;
+    },
+
     isPrivate() {
       if (
         this.currentChat.can_reply ||
         this.isAWhatsAppChannel ||
-        this.isAPIInbox
+        this.isAPIInbox ||
+        this.isInstagramDM ||
+        this.isAFacebookInbox
       ) {
         return this.isOnPrivateNote;
       }
@@ -216,7 +222,7 @@ export default {
     isReplyRestricted() {
       return (
         !this.currentChat?.can_reply &&
-        !(this.isAWhatsAppChannel || this.isAPIInbox)
+        !(this.isAWhatsAppChannel || this.isAPIInbox|| this.isInstagramDM || this.isAFacebookInbox)
       );
     },
     inboxId() {
@@ -468,7 +474,13 @@ export default {
         this.setCCAndToEmailsFromLastChat();
       }
 
-      if (canReply || this.isAWhatsAppChannel || this.isAPIInbox) {
+      if (
+        canReply ||
+        this.isAWhatsAppChannel ||
+        this.isAPIInbox ||
+        this.isInstagramDM ||
+        this.isAFacebookInbox
+      ) {
         this.replyType = REPLY_EDITOR_MODES.REPLY;
       } else {
         this.replyType = REPLY_EDITOR_MODES.NOTE;
@@ -897,7 +909,7 @@ export default {
       this.$store.dispatch('draftMessages/setReplyEditorMode', {
         mode,
       });
-      if (canReply || this.isAWhatsAppChannel || this.isAPIInbox)
+      if (canReply || this.isAWhatsAppChannel || this.isAPIInbox || this.isInstagramDM || this.isAFacebookInbox)
         this.replyType = mode;
       if (this.showRichContentEditor) {
         if (this.isRecordingAudio) {


### PR DESCRIPTION
Fixed the issue preventing replies from being blocked to Instagram and Facebook conversations after 24 hour window.
